### PR TITLE
HIFI-358: Adding ability to set individual attenuation and rolloff per-connection

### DIFF
--- a/src/classes/HiFiAudioAPIData.ts
+++ b/src/classes/HiFiAudioAPIData.ts
@@ -165,7 +165,7 @@ export class HiFiAudioAPIData {
      * ❌ The server never sends `userAttenuation` data.
      *
      * @param userRolloff This value represents the progressive high frequency roll-off in meters, a measure of how the higher frequencies 
-     * in a user's sound are dampened as the user gets further away. By default, there is a global roll-off value (set for a given space), currently 12.5 
+     * in a user's sound are dampened as the user gets further away. By default, there is a global roll-off value (set for a given space), currently 16 
      * meters, which applies to all users in a space. This value represents the distance for a 1kHz rolloff. Values in the range of 
      * 12 to 32 meters provide a more "enclosed" sound, in which high frequencies tend to be dampened over distance as they are 
      * in the real world. Generally changes to roll-off values should be made for the entire space rather than for individual users, but

--- a/src/classes/HiFiAudioAPIData.ts
+++ b/src/classes/HiFiAudioAPIData.ts
@@ -140,28 +140,37 @@ export class HiFiAudioAPIData {
      * ✔ The server sends `hiFiGain` data to all clients connected to a server during "peer updates".
 
      * @param userAttenuation This value affects how far a user's sound will travel in 3D space, without affecting the user's loudness.
-     * By default, there is a global attenuation value (set for a given space) that applies to all users in a space.
+     * By default, there is a global attenuation value (set for a given space) that applies to all users in a space. This default space
+     * attenuation is usually 0.5, which represents a reasonable approximation of a real-world fall-off in sound over distance.
+     * Lower numbers represent less attenuation (i.e. sound travels farther); higher numbers represent more attenuation (i.e. sound drops
+     * off more quickly).
+     * 
+     * When setting this value for an individual user, the following holds:
+     *   - Positive numbers should be between 0 and 1, and they represent a logarithmic attenuation. This range is recommended, as it is
+     * more natural sounding.  Smaller numbers represent less attenuation, so a number such as 0.2 can be used to make a particular 
+     * user's audio travel farther than other users', for instance in "amplified" concert type settings. Similarly, an extremely 
+     * small non-zero number (e.g. 0.00001) can be used to effectively turn off attenuation for a given user within a reasonably 
+     * sized space, resulting in a "broadcast mode" where the user can be heard throughout most of the space regardless of their location
+     * relative to other users. (Note: The actual value "0" is used internally to represent the default; for setting minimal attenuation, 
+     * small non-zero numbers should be used instead. See also "userRolloff" below.)
+     *   - Negative attenuation numbers are used to represent linear attenuation, and are a somewhat artificial, non-real-world concept. However,
+     * this setting can be used as a blunt tool to easily test attenuation, and tune it aggressively in extreme circumstances.
      *
-     * Positive numbers should be between 0 and 1, and they represent exponential attenuation. These numbers are recommended, 
-     * as it is more natural sounding. Default space attenuation is usually 0.5. Lower numbers represent less attenuation (i.e. 
-     * sound travels farther); higher numbers represent more attenuation (i.e. sound drops off more quickly). A number such as 0.2
-     * can be used to make a particular user's audio travel farther than other users, which can be useful for concert type settings.
-     *
-     * Negative numbers are used to represent linear attenuation, and are less natural -- however, this setting can be more
-     * intuitive. An extremely large negative number (e.g. -99999) can be used to effectively turn off attenuation entirely
-     * for a given user, resulting in a "broadcast mode" where the user can be heard throughout most of the space regardless of location
-     * relative to other users. 
-     *
-     * If you don't supply an `userAttenuation` when constructing instantiations of this class, `userAttenuation` will be `null`.
+     * If you don't supply an `userAttenuation` when constructing instantiations of this class, `userAttenuation` will be `null` and the
+     * default will be used.
      * 
      * ✔ The client sends `userAttenuation` data to the server when `_transmitHiFiAudioAPIDataToServer()` is called.
      * 
      * ❌ The server never sends `userAttenuation` data.
-
-     * @param userRolloff This value affects frequency rolloff. Very large numbers mean that rolloff will be effectively disabled.
-     * When setting a user up for a "broadcast mode" it is recommended to set this to a number such as 99999 to effectively
-     * turn off frequency rolloff entirely. Smaller numbers (e.g. 30) can be used to reduce rolloff slightly without turning
-     * it off altogether.
+     *
+     * @param userRolloff This value represents the progressive high frequency roll-off in meters, a measure of how the higher frequencies 
+     * in a user's sound are dampened as the user gets further away. By default, there is a global roll-off value (set for a given space), currently 12.5 
+     * meters, which applies to all users in a space. This value represents the distance for a 1kHz rolloff. Values in the range of 
+     * 12 to 32 meters tend to provide a more "enclosed" sound, in which high frequencies tend to be dampened over distance as they are 
+     * in the real world. Generally changes to roll-off values should be made for the entire space rather than for individual users, but
+     * extremely high values (e.g. 99999) should be used in combination with "broadcast mode"-style userAttenuation settings to cause the
+     * broadcasted voice to sound crisp and "up close" even at very large distances.
+     *
      * If you don't supply an `userRolloff` when constructing instantiations of this class, `userRolloff` will be `null`.
      * 
      * ✔ The client sends `userRolloff` data to the server when `_transmitHiFiAudioAPIDataToServer()` is called.

--- a/src/classes/HiFiAudioAPIData.ts
+++ b/src/classes/HiFiAudioAPIData.ts
@@ -154,7 +154,8 @@ export class HiFiAudioAPIData {
      * relative to other users. (Note: The actual value "0" is used internally to represent the default; for setting minimal attenuation, 
      * small non-zero numbers should be used instead. See also "userRolloff" below.)
      *   - Negative attenuation numbers are used to represent linear attenuation, and are a somewhat artificial, non-real-world concept. However,
-     * this setting can be used as a blunt tool to easily test attenuation, and tune it aggressively in extreme circumstances.
+     * this setting can be used as a blunt tool to easily test attenuation, and tune it aggressively in extreme circumstances. When using linear 
+     * attenuation, the setting is the distance in meters at which the audio becomes totally inaudible.
      *
      * If you don't supply an `userAttenuation` when constructing instantiations of this class, `userAttenuation` will be `null` and the
      * default will be used.
@@ -166,7 +167,7 @@ export class HiFiAudioAPIData {
      * @param userRolloff This value represents the progressive high frequency roll-off in meters, a measure of how the higher frequencies 
      * in a user's sound are dampened as the user gets further away. By default, there is a global roll-off value (set for a given space), currently 12.5 
      * meters, which applies to all users in a space. This value represents the distance for a 1kHz rolloff. Values in the range of 
-     * 12 to 32 meters tend to provide a more "enclosed" sound, in which high frequencies tend to be dampened over distance as they are 
+     * 12 to 32 meters provide a more "enclosed" sound, in which high frequencies tend to be dampened over distance as they are 
      * in the real world. Generally changes to roll-off values should be made for the entire space rather than for individual users, but
      * extremely high values (e.g. 99999) should be used in combination with "broadcast mode"-style userAttenuation settings to cause the
      * broadcasted voice to sound crisp and "up close" even at very large distances.

--- a/src/classes/HiFiAudioAPIData.ts
+++ b/src/classes/HiFiAudioAPIData.ts
@@ -108,6 +108,8 @@ export class HiFiAudioAPIData {
     orientationEuler: OrientationEuler3D;
     orientationQuat: OrientationQuat3D;
     hiFiGain: number;
+    userAttenuation: number;
+    userRolloff: number;
 
     /**
      * 
@@ -127,6 +129,7 @@ export class HiFiAudioAPIData {
      * ✔ The client sends `orientationQuat` data to the server when `_transmitHiFiAudioAPIDataToServer()` is called.
      * 
      * ✔ The server sends `orientationQuat` data to all clients connected to a server during "peer updates".
+
      * @param hiFiGain This value affects how loud User A will sound to User B at a given distance in 3D space.
      * This value also affects the distance at which User A can be heard in 3D space.
      * Higher values for User A means that User A will sound louder to other users around User A, and it also means that User A will be audible from a greater distance.
@@ -135,12 +138,43 @@ export class HiFiAudioAPIData {
      * ✔ The client sends `hiFiGain` data to the server when `_transmitHiFiAudioAPIDataToServer()` is called.
      * 
      * ✔ The server sends `hiFiGain` data to all clients connected to a server during "peer updates".
+
+     * @param userAttenuation This value affects how far a user's sound will travel in 3D space, without affecting the user's loudness.
+     * By default, there is a global attenuation value (set for a given space) that applies to all users in a space.
+     *
+     * Positive numbers should be between 0 and 1, and they represent exponential attenuation. These numbers are recommended, 
+     * as it is more natural sounding. Default space attenuation is usually 0.5. Lower numbers represent less attenuation (i.e. 
+     * sound travels farther); higher numbers represent more attenuation (i.e. sound drops off more quickly). A number such as 0.2
+     * can be used to make a particular user's audio travel farther than other users, which can be useful for concert type settings.
+     *
+     * Negative numbers are used to represent linear attenuation, and are less natural -- however, this setting can be more
+     * intuitive. An extremely large negative number (e.g. -99999) can be used to effectively turn off attenuation entirely
+     * for a given user, resulting in a "broadcast mode" where the user can be heard throughout most of the space regardless of location
+     * relative to other users. 
+     *
+     * If you don't supply an `userAttenuation` when constructing instantiations of this class, `userAttenuation` will be `null`.
+     * 
+     * ✔ The client sends `userAttenuation` data to the server when `_transmitHiFiAudioAPIDataToServer()` is called.
+     * 
+     * ❌ The server never sends `userAttenuation` data.
+
+     * @param userRolloff This value affects frequency rolloff. Very large numbers mean that rolloff will be effectively disabled.
+     * When setting a user up for a "broadcast mode" it is recommended to set this to a number such as 99999 to effectively
+     * turn off frequency rolloff entirely. Smaller numbers (e.g. 30) can be used to reduce rolloff slightly without turning
+     * it off altogether.
+     * If you don't supply an `userRolloff` when constructing instantiations of this class, `userRolloff` will be `null`.
+     * 
+     * ✔ The client sends `userRolloff` data to the server when `_transmitHiFiAudioAPIDataToServer()` is called.
+     * 
+     * ❌ The server never sends `userRolloff` data.
      */
-    constructor({ position = null, orientationEuler = null, orientationQuat = null, hiFiGain = null }: { position?: Point3D, orientationEuler?: OrientationEuler3D, orientationQuat?: OrientationQuat3D, hiFiGain?: number } = {}) {
+    constructor({ position = null, orientationEuler = null, orientationQuat = null, hiFiGain = null, userAttenuation = null, userRolloff = null }: { position?: Point3D, orientationEuler?: OrientationEuler3D, orientationQuat?: OrientationQuat3D, hiFiGain?: number, userAttenuation?: number, userRolloff?: number } = {}) {
         this.position = position;
         this.orientationQuat = orientationQuat;
         this.orientationEuler = orientationEuler;
         this.hiFiGain = hiFiGain;
+        this.userAttenuation = userAttenuation;
+        this.userRolloff = userRolloff;
     }
 
     /**
@@ -157,6 +191,12 @@ export class HiFiAudioAPIData {
         if (typeof (this.hiFiGain) === "number") {
             currentHiFiAudioAPIDataObj["hiFiGain"] = this.hiFiGain;
         }
+        if (typeof (this.userAttenuation) === "number") {
+            currentHiFiAudioAPIDataObj["userAttenuation"] = this.userAttenuation;
+        }
+        if (typeof (this.userRolloff) === "number") {
+            currentHiFiAudioAPIDataObj["userRolloff"] = this.userRolloff;
+        }
 
         let otherHiFiDataObj: any = {
             "position": Object.assign({}, otherHiFiData.position),
@@ -165,6 +205,12 @@ export class HiFiAudioAPIData {
         };
         if (typeof (otherHiFiData.hiFiGain) === "number") {
             otherHiFiDataObj["hiFiGain"] = otherHiFiData.hiFiGain;
+        }
+        if (typeof (otherHiFiData.userAttenuation) === "number") {
+            otherHiFiDataObj["userAttenuation"] = otherHiFiData.userAttenuation;
+        }
+        if (typeof (otherHiFiData.userRolloff) === "number") {
+            otherHiFiDataObj["userRolloff"] = otherHiFiData.userRolloff;
         }
 
         let diffObject = recursivelyDiffObjects(currentHiFiAudioAPIDataObj, otherHiFiDataObj);
@@ -187,6 +233,12 @@ export class HiFiAudioAPIData {
 
         if (typeof (diffObject.hiFiGain) === "number") {
             returnValue.hiFiGain = diffObject.hiFiGain;
+        }
+        if (typeof (diffObject.userAttenuation) === "number") {
+            returnValue.userAttenuation = diffObject.userAttenuation;
+        }
+        if (typeof (diffObject.userRolloff) === "number") {
+            returnValue.userRolloff = diffObject.userRolloff;
         }
 
         return returnValue;

--- a/src/classes/HiFiCommunicator.ts
+++ b/src/classes/HiFiCommunicator.ts
@@ -416,8 +416,12 @@ export class HiFiCommunicator {
      * This value also affects the distance at which User A can be heard in 3D space.
      * Higher values for User A means that User A will sound louder to other users around User A, and it also means that User A will be audible from a greater distance.
      * The new hiFiGain of the user.
+     * @param userAttenuation - This value affects how far a user's voice will travel in 3D space.
+     * The new attenuation value for the user.
+     * @param userRolloff - This value affects the frequency rolloff for a given user.
+     * The new rolloff value for the user.
      */
-    private _updateUserData({ position, orientationEuler, orientationQuat, hiFiGain }: { position?: Point3D, orientationEuler?: OrientationEuler3D, orientationQuat?: OrientationQuat3D, hiFiGain?: number } = {}): void {
+    private _updateUserData({ position, orientationEuler, orientationQuat, hiFiGain, userAttenuation, userRolloff }: { position?: Point3D, orientationEuler?: OrientationEuler3D, orientationQuat?: OrientationQuat3D, hiFiGain?: number, userAttenuation?: number, userRolloff?: number } = {}): void {
         if (position) {
             if (!this._currentHiFiAudioAPIData.position) {
                 this._currentHiFiAudioAPIData.position = new Point3D();
@@ -456,6 +460,13 @@ export class HiFiCommunicator {
 
         if (typeof (hiFiGain) === "number") {
             this._currentHiFiAudioAPIData.hiFiGain = Math.max(0, hiFiGain);
+        }
+        if (typeof (userAttenuation) === "number") {
+            this._currentHiFiAudioAPIData.userAttenuation = userAttenuation;
+        }
+        if (typeof (userRolloff) === "number") {
+            // TODO: will this ever be negative legitimately?
+            this._currentHiFiAudioAPIData.userRolloff = Math.max(0, userRolloff);
         }
     }
 
@@ -517,6 +528,12 @@ export class HiFiCommunicator {
 
         if (typeof (dataJustTransmitted.hiFiGain) === "number") {
             this._lastTransmittedHiFiAudioAPIData["hiFiGain"] = dataJustTransmitted.hiFiGain;
+        }
+        if (typeof (dataJustTransmitted.userAttenuation) === "number") {
+            this._lastTransmittedHiFiAudioAPIData["userAttenuation"] = dataJustTransmitted.userAttenuation;
+        }
+        if (typeof (dataJustTransmitted.userRolloff) === "number") {
+            this._lastTransmittedHiFiAudioAPIData["userRolloff"] = dataJustTransmitted.userRolloff;
         }
     }
 

--- a/src/classes/HiFiCommunicator.ts
+++ b/src/classes/HiFiCommunicator.ts
@@ -465,7 +465,6 @@ export class HiFiCommunicator {
             this._currentHiFiAudioAPIData.userAttenuation = userAttenuation;
         }
         if (typeof (userRolloff) === "number") {
-            // TODO: will this ever be negative legitimately?
             this._currentHiFiAudioAPIData.userRolloff = Math.max(0, userRolloff);
         }
     }

--- a/src/classes/HiFiMixerSession.ts
+++ b/src/classes/HiFiMixerSession.ts
@@ -719,6 +719,15 @@ export class HiFiMixerSession {
             dataForMixer["g"] = Math.max(0, hifiAudioAPIData.hiFiGain);
         }
 
+        if (typeof (hifiAudioAPIData.userAttenuation) === "number") {
+            dataForMixer["a"] = hifiAudioAPIData.userAttenuation;
+        }
+
+        if (typeof (hifiAudioAPIData.userRolloff) === "number") {
+            // TODO: Should this ever go negative?
+            dataForMixer["r"] = Math.max(0, hifiAudioAPIData.userRolloff);
+        }
+
         if (Object.keys(dataForMixer).length === 0) {
             // We call this a "success" even though we didn't send anything to the mixer.
             return {

--- a/src/classes/HiFiMixerSession.ts
+++ b/src/classes/HiFiMixerSession.ts
@@ -724,7 +724,6 @@ export class HiFiMixerSession {
         }
 
         if (typeof (hifiAudioAPIData.userRolloff) === "number") {
-            // TODO: Should this ever go negative?
             dataForMixer["r"] = Math.max(0, hifiAudioAPIData.userRolloff);
         }
 


### PR DESCRIPTION
New `userAttenuation` and `userRolloff` settings on HiFiAudioAPIData.ts, plus documentation. Requires running v1.26.2 on the server side.

(Currently working on adding an example of usage to the "complex" sample app as well.)