### PR TITLE
Add feature detection for browser compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import { checkBrowserCompatibility } from "./utilities/HiFiUtilities";
 let isBrowserContext = typeof self !== 'undefined';
 if (isBrowserContext) {
     exports.HiFiAPIVersion = HIFI_API_VERSION;
+    exports.apiVersion = HIFI_API_VERSION;
+    exports.checkBrowserCompatibility = checkBrowserCompatibility;
     checkBrowserCompatibility();
 }
 
@@ -55,10 +57,6 @@ exports.HiFiAxisConfiguration = HiFiAxisConfiguration;
 // Short synonyms for the above start here!
 // Please let us know if any of these `exports` cause namespace collisions
 // in your application.
-
-if (isBrowserContext) {
-    exports.apiVersion = HIFI_API_VERSION;
-}
 
 exports.Communicator = HiFiCommunicator;
 exports.ConnectionStates = HiFiConnectionStates;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,11 @@ declare var HIFI_API_VERSION: string;
 
 // Check for browser compatibility
 import { checkBrowserCompatibility } from "./utilities/HiFiUtilities";
-checkBrowserCompatibility();
+let isBrowserContext = typeof self !== 'undefined';
+if (isBrowserContext) {
+    exports.HiFiAPIVersion = HIFI_API_VERSION;
+    checkBrowserCompatibility();
+}
 
 import { HiFiAudioAPIData, ReceivedHiFiAudioAPIData, OrientationEuler3D, OrientationQuat3D, Point3D, eulerToQuaternion, eulerFromQuaternion} from "./classes/HiFiAudioAPIData";
 import { HiFiCommunicator, HiFiConnectionStates, HiFiUserDataStreamingScopes } from "./classes/HiFiCommunicator";
@@ -19,11 +23,6 @@ import { HiFiAxes, HiFiHandedness, HiFiAxisConfiguration } from "./classes/HiFiA
 // Some people don't want to type `HiFi` every time they want to use our Client Library,
 // so we also offer shorter synonyms for every Library entry point.
 // Scroll down to check out those shorter synonyms.
-
-let isBrowserContext = typeof self !== 'undefined';
-if (isBrowserContext) {
-    exports.HiFiAPIVersion = HIFI_API_VERSION;
-}
 
 exports.HiFiCommunicator = HiFiCommunicator;
 exports.HiFiConnectionStates = HiFiConnectionStates;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,9 @@
 declare var HIFI_API_VERSION: string;
 
+// Check for browser compatibility
+import { checkBrowserCompatibility } from "./utilities/HiFiUtilities";
+checkBrowserCompatibility();
+
 import { HiFiAudioAPIData, ReceivedHiFiAudioAPIData, OrientationEuler3D, OrientationQuat3D, Point3D, eulerToQuaternion, eulerFromQuaternion} from "./classes/HiFiAudioAPIData";
 import { HiFiCommunicator, HiFiConnectionStates, HiFiUserDataStreamingScopes } from "./classes/HiFiCommunicator";
 import { AvailableUserDataSubscriptionComponents, UserDataSubscription } from "./classes/HiFiUserDataSubscription";

--- a/src/utilities/HiFiUtilities.ts
+++ b/src/utilities/HiFiUtilities.ts
@@ -186,3 +186,40 @@ export function preciseInterval(callback: Function, intervalMS: number): any {
     let timeout:any = setTimeout(wrapper);
     return { clear: () => clear(timeout) };
 }
+
+export function checkBrowserCompatibility(): Boolean {
+    let requiredFeatures: Array<string> = [
+        // Navigator mediaDevices
+        "navigator",
+        "navigator.permissions",
+        "navigator.permissions.query",
+        "navigator.mediaDevices.getUserMedia",
+        "navigator.mediaDevices.getSupportedConstraints",
+        // WebRTC
+        "window.MediaStream",
+        "window.MediaStreamTrack",
+        "window.RTCDataChannel",
+        "window.RTCDataChannelEvent",
+        "window.RTCDtlsTransport",
+        "window.RTCIceCandidate",
+        "window.RTCIceTransport",
+        "window.RTCPeerConnection",
+        "window.RTCPeerConnectionIceEvent",
+        "window.RTCRtpReceiver",
+        "window.RTCRtpSender",
+        "window.RTCRtpTransceiver",
+        "window.RTCSctpTransport",
+        "window.RTCSessionDescription"
+    ]
+    for (let i = 0; i < requiredFeatures.length; i++) {
+        if (typeof(eval(requiredFeatures[i])) === "undefined") {
+            console.log("HiFi Audio API: The browser does not support: " + requiredFeatures[i]);
+            if (requiredFeatures[i] === "navigator.mediaDevices.getUserMedia") {
+                console.log("HiFi Audio API: It might be preventing access to this feature on insecure contexts.")
+            }
+            return false;
+        }
+    }
+    console.log("HiFi Audio API: The browser supports all feature requirements.")
+    return true;
+}

--- a/src/utilities/HiFiUtilities.ts
+++ b/src/utilities/HiFiUtilities.ts
@@ -213,13 +213,12 @@ export function checkBrowserCompatibility(): Boolean {
     ]
     for (let i = 0; i < requiredFeatures.length; i++) {
         if (typeof(eval(requiredFeatures[i])) === "undefined") {
-            console.log("HiFi Audio API: The browser does not support: " + requiredFeatures[i]);
+            HiFiLogger.error("HiFi Audio API: The browser does not support: " + requiredFeatures[i]);
             if (requiredFeatures[i] === "navigator.mediaDevices.getUserMedia") {
-                console.log("HiFi Audio API: It might be preventing access to this feature on insecure contexts.")
+                HiFiLogger.error("HiFi Audio API: Your browser may be preventing access to this feature if you are running in an insecure context, i.e. an `http` server.");
             }
             return false;
         }
     }
-    console.log("HiFi Audio API: The browser supports all feature requirements.")
     return true;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
         "outDir": "./dist/",
         "noImplicitAny": true,
         "module": "commonjs",
-        "target": "es6",
+        "target": "es5",
         "removeComments": true,
         "preserveConstEnums": true,
         "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
         "outDir": "./dist/",
         "noImplicitAny": true,
         "module": "commonjs",
-        "target": "es5",
+        "target": "es6",
         "removeComments": true,
         "preserveConstEnums": true,
         "sourceMap": true,


### PR DESCRIPTION
This PR increases compatibility by setting the ts compiler target to `ES5`. A check for required features will be performed before executing the API code. This way the browser will prompt the user via console before other errors occur.