### PR TITLE
HIFI-503: When the "can't connect to mixer" promise rejects, reject with the correct error message

### DIFF
--- a/src/classes/HiFiMixerSession.ts
+++ b/src/classes/HiFiMixerSession.ts
@@ -400,12 +400,12 @@ export class HiFiMixerSession {
 
         this._currentHiFiConnectionState = undefined;
 
+        let mixerIsUnavailable = false;
         const tempUnavailableStateHandler = (event: any) => {
             if (event && event.state === RaviSignalingStates.UNAVAILABLE) {
-                let errMsg = `High Fidelity server is at capacity; service is unavailable.`;
+                mixerIsUnavailable = true;
                 this._raviSignalingConnection.removeStateChangeHandler(tempUnavailableStateHandler);
                 this._raviSession.closeRAVISession();
-                return Promise.reject(errMsg);
             }
         }
         this._raviSignalingConnection.addStateChangeHandler(tempUnavailableStateHandler);
@@ -423,6 +423,9 @@ export class HiFiMixerSession {
             await this._raviSession.openRAVISession({ signalingConnection: this._raviSignalingConnection, params: webRTCSessionParams });
         } catch (errorOpeningRAVISession) {
             let errMsg = `Couldn't open RAVI session associated with \`${this.webRTCAddress.slice(0, this.webRTCAddress.indexOf("token="))}<token redacted>\`! Error:\n${errorOpeningRAVISession}`;
+            if (mixerIsUnavailable) {
+                errMsg = `High Fidelity server is at capacity; service is unavailable.`;
+            }
             this.disconnectFromHiFiMixer();
             this._raviSignalingConnection.removeStateChangeHandler(tempUnavailableStateHandler);
             return Promise.reject(errMsg);


### PR DESCRIPTION
In general, the flow will be like this: 

1. Signaling connection tries to connect and resolves that promise
2. RAVI session starts trying to connect
3. Signaling connection sends the "unavailable" message and disconnects
4. Handler kicks in and sets status to 'unavailable'
5. RAVI session stops trying to connect and rejects its promise

This covers that flow by setting a flag at step 4 that step 5 can swoop in and read, so that it sets the right information for the promise.reject.

There's maybe a possibility that things will happen in a different order, e.g.: 1, 2, 3, 5, 4 -- in this situation, that #5 promise will reject first, and the user would not get the correct 'unavailable' message. However, any handlers that the developer might have set for state changes would still trigger for the 'unknown' status, so they could catch that there.