### PR TITLE
HIFI-393: Use port 443 for signaling by default

### DIFF
--- a/src/constants/HiFiConstants.ts
+++ b/src/constants/HiFiConstants.ts
@@ -21,6 +21,10 @@ export class HiFiConstants {
      * The production endpoint for our High Fidelity audio connections.
      */
     static DEFAULT_PROD_HIGH_FIDELITY_ENDPOINT: string = "api.highfidelity.com";
+    /**
+     * The default port for signaling connections to our High Fidelity audio servers.
+     */
+    static DEFAULT_PROD_HIGH_FIDELITY_PORT: number = 443;
 
     constructor() {}
 };


### PR DESCRIPTION
and make that port configurable while we're at it.

NOTE: Requires deployment of Infra PR 358 as well, which is expected to be live as of the April 8 2021 planned release. Hold off on merging this until that's released!