### PR TITLE
Remove receiving hiFiGain

### DIFF
--- a/src/classes/HiFiAudioAPIData.ts
+++ b/src/classes/HiFiAudioAPIData.ts
@@ -515,7 +515,7 @@ export class ReceivedHiFiAudioAPIData extends HiFiAudioAPIData {
      */
     isStereo: boolean;
     
-    constructor(params: { providedUserID?: string, hashedVisitID?: string, volumeDecibels?: number, position?: Point3D, orientationQuat?: OrientationQuat3D, hiFiGain?: number, isStereo?: boolean } = {}) {
+    constructor(params: { providedUserID?: string, hashedVisitID?: string, volumeDecibels?: number, position?: Point3D, orientationQuat?: OrientationQuat3D, isStereo?: boolean } = {}) {
         super(params);
         this.providedUserID = params.providedUserID;
         this.hashedVisitID = params.hashedVisitID;

--- a/src/classes/HiFiCommunicator.ts
+++ b/src/classes/HiFiCommunicator.ts
@@ -742,12 +742,6 @@ export class HiFiCommunicator {
                             }
                             break;
 
-                        case AvailableUserDataSubscriptionComponents.HiFiGain:
-                            if (typeof (currentDataFromServer.hiFiGain) === "number") {
-                                newCallbackData.hiFiGain = currentDataFromServer.hiFiGain;
-                                shouldPushNewCallbackData = true;
-                            }
-                            break;
                         case AvailableUserDataSubscriptionComponents.IsStereo:
                             if (typeof (currentDataFromServer.isStereo) === "boolean") {
                                 newCallbackData.isStereo = currentDataFromServer.isStereo;

--- a/src/classes/HiFiMixerSession.ts
+++ b/src/classes/HiFiMixerSession.ts
@@ -443,14 +443,6 @@ export class HiFiMixerSession {
                     serverSentNewUserData = true;
                 }
 
-
-                // `ReceivedHiFiAudioAPIData.hiFiGain`
-                if (typeof (peerDataFromMixer.g) === "number") {
-                    userDataCache.hiFiGain = peerDataFromMixer.g;
-                    newUserData.hiFiGain = peerDataFromMixer.g;
-                    serverSentNewUserData = true;
-                }
-
                 // `ReceivedHiFiAudioAPIData.volumeDecibels`
                 if (typeof (peerDataFromMixer.v) === "number") {
                     userDataCache.volumeDecibels = peerDataFromMixer.v;

--- a/src/classes/HiFiUserDataSubscription.ts
+++ b/src/classes/HiFiUserDataSubscription.ts
@@ -13,7 +13,6 @@ export enum AvailableUserDataSubscriptionComponents {
     OrientationEuler = "Orientation (Euler)",
     OrientationQuat = "Orientation (Quaternion)",
     VolumeDecibels = "Volume (Decibels)",
-    HiFiGain = "HiFiGain",
     IsStereo = "IsStereo"
 }
 


### PR DESCRIPTION
HIFI-597 - Removed references to receiving hiFiGain:

1. removed enum from HiFiUserDataSubscription.ts
2. removed case for AvailableUserDataSubscriptionComponents.HiFiGain in HiFiCommunicator.ts
3. removed hiFiGain block from HiFiMixerSession.ts