### PR TITLE
Fine-tuning of connection behavior

### DIFF
--- a/src/classes/HiFiCommunicator.ts
+++ b/src/classes/HiFiCommunicator.ts
@@ -234,8 +234,8 @@ export class HiFiCommunicator {
 
         if (this._mixerSession.getCurrentHiFiConnectionState() === HiFiConnectionStates.Connected) {
             let errMsg = `Session is already connected! If you need to reset the connection, please disconnect fully and call this method again.`;
-            return Promise.reject({
-                success: false,
+            return Promise.resolve({
+                success: true,
                 error: errMsg
             });
         }

--- a/src/classes/HiFiCommunicator.ts
+++ b/src/classes/HiFiCommunicator.ts
@@ -348,6 +348,19 @@ export class HiFiCommunicator {
     }
 
     /**
+     * @returns The current state of the connection to High Fidelity, as one of the HiFiConnectionStates.
+     * This will return null if the current state is not available (e.g. if the HiFiCommunicator
+     * is still in the process of initializing its underlying HiFiMixerSession).
+     */
+    getConnectionState(): HiFiConnectionStates {
+        if (this._mixerSession) {
+            return this._mixerSession.getCurrentHiFiConnectionState();
+        } else {
+            return null;
+        }
+    }
+
+    /**
      * Use this function to set the `MediaStream` associated with the user. This `MediaStream` will be sent up to the High Fidelity Audio Servers and
      * mixed with other users' audio streams. The resultant mixed stream will be sent to all connected clients.
      *

--- a/src/classes/HiFiCommunicator.ts
+++ b/src/classes/HiFiCommunicator.ts
@@ -102,8 +102,8 @@ export class HiFiCommunicator {
      * @param userDataStreamingScope - Cannot be set later. See {@link HiFiUserDataStreamingScopes}.
      * @param hiFiAxisConfiguration - Cannot be set later. The 3D axis configuration. See {@link ourHiFiAxisConfiguration} for defaults.
      * @param webrtcSessionParams - Cannot be set later. Extra parameters used for configuring the underlying WebRTC connection to the API servers.
-     * @param onMuteChanged - A function that will be called when the mute state of the client has changed, for example when muted by an admin. See {@link OnMuteChangedCallback} for the information this function will receive.
      * These settings are not frequently used; they are primarily for specific jitter buffer configurations.
+     * @param onMuteChanged - A function that will be called when the mute state of the client has changed, for example when muted by an admin. See {@link OnMuteChangedCallback} for the information this function will receive.
      */
     constructor({
         initialHiFiAudioAPIData = new HiFiAudioAPIData(),
@@ -225,7 +225,15 @@ export class HiFiCommunicator {
      */
     async connectToHiFiAudioAPIServer(hifiAuthJWT: string, signalingHostURL?: string, signalingPort?: number): Promise<any> {
         if (!this._mixerSession) {
-            let errMsg = `\`this._mixerSession\` is falsey!`;
+            let errMsg = `\`this._mixerSession\` is falsey; try creating a new HiFiCommunicator and starting over.`;
+            return Promise.reject({
+                success: false,
+                error: errMsg
+            });
+        }
+
+        if (this._mixerSession.getCurrentHiFiConnectionState() === HiFiConnectionStates.Connected) {
+            let errMsg = `Session is already connected! If you need to reset the connection, please disconnect fully and call this method again.`;
             return Promise.reject({
                 success: false,
                 error: errMsg
@@ -248,11 +256,13 @@ export class HiFiCommunicator {
             let webRTCSignalingAddress = `wss://${signalingHostURLSafe}:${signalingPort}/?token=`;
             this._mixerSession.webRTCAddress = `${webRTCSignalingAddress}${hifiAuthJWT}`;
 
-            HiFiLogger.log(`Using WebRTC Signaling Address:\n${webRTCSignalingAddress}<token redacted>`);
+            HiFiLogger.log(`Using WebRTC Signaling Address:
+${webRTCSignalingAddress}<token redacted>`);
 
             mixerConnectionResponse = await this._mixerSession.connectToHiFiMixer({ webRTCSessionParams: this._webRTCSessionParams });
         } catch (errorConnectingToMixer) {
-            let errMsg = `Error when connecting to mixer! Error:\n${errorConnectingToMixer}`;
+            let errMsg = `Error when connecting to mixer!
+${errorConnectingToMixer}`;
             return Promise.reject({
                 success: false,
                 error: errMsg
@@ -815,7 +825,8 @@ export class HiFiCommunicator {
             return;
         }
 
-        HiFiLogger.log(`Adding new User Data Subscription:\n${JSON.stringify(newSubscription)}`);
+        HiFiLogger.log(`Adding new User Data Subscription:
+${JSON.stringify(newSubscription)}`);
         this._userDataSubscriptions.push(newSubscription);
     }
 }

--- a/src/classes/HiFiMixerSession.ts
+++ b/src/classes/HiFiMixerSession.ts
@@ -510,6 +510,12 @@ export class HiFiMixerSession {
      * @returns A Promise that rejects with an error message string upon failure, or resolves with the response from `audionet.init` as a string.
      */
     async connectToHiFiMixer({ webRTCSessionParams }: { webRTCSessionParams?: WebRTCSessionParams }): Promise<any> {
+
+        if (this._currentHiFiConnectionState === HiFiConnectionStates.Connected && this.mixerInfo["connected"]) {
+            let errMsg = `Already connected! If a reconnect is needed, explicitly disconnect and try again.`;
+            return Promise.reject(errMsg);
+        }
+
         if (!this.webRTCAddress) {
             let errMsg = `Couldn't connect: \`this.webRTCAddress\` is falsey!`;
             this.disconnectFromHiFiMixer();

--- a/src/classes/HiFiMixerSession.ts
+++ b/src/classes/HiFiMixerSession.ts
@@ -832,7 +832,14 @@ export class HiFiMixerSession {
     }
 
     /**
-     * Fires when the RAVI Signaling State chantges.
+     * Return the current state of the connection.
+     */
+    getCurrentHiFiConnectionState(): HiFiConnectionStates {
+        return this._currentHiFiConnectionState;
+    }
+
+    /**
+     * Fires when the RAVI Signaling State changes.
      * @param event 
      */
     onRAVISignalingStateChanged(event: any): void {

--- a/src/libravi/RaviSignalingConnection.ts
+++ b/src/libravi/RaviSignalingConnection.ts
@@ -370,6 +370,14 @@ class RaviSignalingWebSocketImplementation {
    * @private
    */
   _open(socketAddress: string) {
+
+    // If we already have an open websocket, just log and return
+    if (this._webSocket && this._webSocket.readyState === crossPlatformWebSocket.OPEN) {
+        RaviUtils.err("There is already an open WebSocket connection. To reconnect, first close the existing WebSocket and then attempt to open again.",
+                "RaviSignalingWebSocketImplementation");
+        return;
+    }
+
     this._webSocket = new crossPlatformWebSocket(socketAddress);
 
     // The WebSocket's open, error, and close events will just


### PR DESCRIPTION
**HIFI-603**: HiFiCommunicator's `connectToHiFiAudioAPIServer` method will now return immediately if the connection is already, uh, connected. (In the end I opted to make this a "success" rather than a failure because I figure it did accomplish the presumed goal, which was to connect - but I waffled a bit, especially because it has a different return (a message rather than results of audionet.init.)

**HIFI-602**: New `getConnectionState()` method on HiFiCommunicator so that users can easily check the status of the connection at any time.

**HIFI-586**: Now appropriately `await`s disconnect attempts. This was resulting in issues when trying to immediately retry connection attempts after they had failed.

**Unrelated changes:**
- Adjusted a comment slightly 
- Changed all of the "\n"s that were embedded in template literals to be actual newlines, because I was getting sick of seeing "\n"s scattered all throughout the text of log messages. This may be a controversial change, because it breaks indentation (so that we don't just end up replacing "\n" with lots of spaces). All I can say is that if we want to use template literals, we have to take the good with the bad (unless someone can tell me how to get the console output to output an actual newline instead of a \n when it's embedded inside a template literal, in which case I will happily switch back to them).