### PR TITLE
get websocket port from url when available

### DIFF
--- a/src/classes/HiFiCommunicator.ts
+++ b/src/classes/HiFiCommunicator.ts
@@ -244,7 +244,13 @@ export class HiFiCommunicator {
         let signalingHostURLSafe;
 
         try {
-            signalingHostURLSafe = new URL(signalingHostURL).hostname;
+            let url = new URL(signalingHostURL);
+            signalingHostURLSafe = url.hostname;
+            if (signalingPort == null && url.port !== "") {
+                // sometimes the signalingPort is specified in the signalHostURL in which case
+                // we extract the port number rather than fallback to default
+                signalingPort = Number(url.port);
+            }
         } catch(e) {
             // If signalingHostURL is not defined, we assign the default URL
             signalingHostURLSafe = signalingHostURL ? signalingHostURL : HiFiConstants.DEFAULT_PROD_HIGH_FIDELITY_ENDPOINT;


### PR DESCRIPTION
This PR fixes a bug that bit me when trying to connect to local assignment client: my `hostname:port` setting was being ignored and my web client would try to connect to default services.