### PR TITLE
HIFI-617: Provide the ability for a user to specify their own STUN/TURN server

### DIFF
--- a/src/classes/HiFiCommunicator.ts
+++ b/src/classes/HiFiCommunicator.ts
@@ -9,7 +9,7 @@
 declare var HIFI_API_VERSION: string;
 
 import { HiFiConstants } from "../constants/HiFiConstants";
-import { WebRTCSessionParams } from "../libravi/RaviSession";
+import { WebRTCSessionParams, CustomSTUNandTURNConfig } from "../libravi/RaviSession";
 import { HiFiLogger } from "../utilities/HiFiLogger";
 import { HiFiUtilities } from "../utilities/HiFiUtilities";
 import { HiFiAudioAPIData, ReceivedHiFiAudioAPIData, Point3D, OrientationQuat3D, OrientationEuler3D, OrientationEuler3DOrder, eulerToQuaternion, eulerFromQuaternion, OtherUserGainMap } from "./HiFiAudioAPIData";
@@ -88,6 +88,7 @@ export class HiFiCommunicator {
     private _mixerSession: HiFiMixerSession;
 
     private _webRTCSessionParams?: WebRTCSessionParams;
+    private _customSTUNandTURNConfig?: CustomSTUNandTURNConfig;
 
     /**
      * Constructor for the HiFiCommunicator object. Once you have created a HiFiCommunicator, you can use the
@@ -103,6 +104,10 @@ export class HiFiCommunicator {
      * @param hiFiAxisConfiguration - Cannot be set later. The 3D axis configuration. See {@link ourHiFiAxisConfiguration} for defaults.
      * @param webrtcSessionParams - Cannot be set later. Extra parameters used for configuring the underlying WebRTC connection to the API servers.
      * These settings are not frequently used; they are primarily for specific jitter buffer configurations.
+     * @param customSTUNandTURNConfig - Cannot be set later. This object can be used if specific STUN and TURN server information needs to be
+     * provided for negotiating the underlying WebRTC connection. By default, High Fidelity's TURN server will be used, which should suffice
+     * for most operations. This is primarily useful for testing or for using a commercial TURN server provider for dealing with particularly challenging client networks/firewalls.
+     * See {@link CustomSTUNandTURNConfig} for the format of this object (note that _all_ values must be provided when setting this).
      * @param onMuteChanged - A function that will be called when the mute state of the client has changed, for example when muted by an admin. See {@link OnMuteChangedCallback} for the information this function will receive.
      */
     constructor({
@@ -113,6 +118,7 @@ export class HiFiCommunicator {
         userDataStreamingScope = HiFiUserDataStreamingScopes.All,
         hiFiAxisConfiguration,
         webrtcSessionParams,
+        customSTUNandTURNConfig,
         onMuteChanged
     }: {
         initialHiFiAudioAPIData?: HiFiAudioAPIData,
@@ -122,8 +128,27 @@ export class HiFiCommunicator {
         userDataStreamingScope?: HiFiUserDataStreamingScopes,
         hiFiAxisConfiguration?: HiFiAxisConfiguration,
         webrtcSessionParams?: WebRTCSessionParams,
+        customSTUNandTURNConfig?: CustomSTUNandTURNConfig,
         onMuteChanged?: OnMuteChangedCallback,
     } = {}) {
+        // If user passed in their own stun/turn config, make sure it matches our interface (ish).
+        // (I do so wish that TypeScript could just do this for us based on the interface definition, but it seems that it can not.)
+        if (customSTUNandTURNConfig) {
+            if (!customSTUNandTURNConfig.hasOwnProperty("stunUrls") || !Array.isArray(customSTUNandTURNConfig.stunUrls) || customSTUNandTURNConfig.stunUrls.length == 0 ) {
+                throw new Error(`\`customSTUNandTURNConfig.stunUrls\` must be specified and must be a list containing at least one STUN server.`);
+            }
+            if (!customSTUNandTURNConfig.hasOwnProperty("turnUrls") || !Array.isArray(customSTUNandTURNConfig.turnUrls) || customSTUNandTURNConfig.turnUrls.length == 0 ) {
+                throw new Error(`\`customSTUNandTURNConfig.turnUrls\` must be specified and must be a list containing at least one TURN server.`);
+            }
+            if (!customSTUNandTURNConfig.hasOwnProperty("turnUsername")) {
+                throw new Error(`\`customSTUNandTURNConfig.turnUsername\` must be specified.`);
+            }
+            if (!customSTUNandTURNConfig.hasOwnProperty("turnCredential")) {
+                throw new Error(`\`customSTUNandTURNConfig.turnCredential\` must be specified.`);
+            }
+        }
+        this._customSTUNandTURNConfig = customSTUNandTURNConfig;
+
         // Make minimum 10ms
         if (transmitRateLimitTimeoutMS < HiFiConstants.MIN_TRANSMIT_RATE_LIMIT_TIMEOUT_MS) {
             HiFiLogger.warn(`\`transmitRateLimitTimeoutMS\` must be >= ${HiFiConstants.MIN_TRANSMIT_RATE_LIMIT_TIMEOUT_MS}ms! Setting to ${HiFiConstants.MIN_TRANSMIT_RATE_LIMIT_TIMEOUT_MS}ms...`);
@@ -264,7 +289,7 @@ export class HiFiCommunicator {
 
             HiFiLogger.log(`Using WebRTC Signaling Address:\n${webRTCSignalingAddress}<token redacted>`);
 
-            mixerConnectionResponse = await this._mixerSession.connectToHiFiMixer({ webRTCSessionParams: this._webRTCSessionParams });
+            mixerConnectionResponse = await this._mixerSession.connectToHiFiMixer({ webRTCSessionParams: this._webRTCSessionParams, customSTUNandTURNConfig: this._customSTUNandTURNConfig });
         } catch (errorConnectingToMixer) {
             let errMsg = `Error when connecting to mixer!\n${errorConnectingToMixer}`;
             return Promise.reject({

--- a/src/classes/HiFiMixerSession.ts
+++ b/src/classes/HiFiMixerSession.ts
@@ -8,12 +8,8 @@ import { HiFiAudioAPIData, OrientationQuat3D, Point3D, ReceivedHiFiAudioAPIData,
 import { HiFiLogger } from "../utilities/HiFiLogger";
 import { HiFiConnectionStates, HiFiUserDataStreamingScopes } from "./HiFiCommunicator";
 
-// We use @ts-ignore here so TypeScript doesn't complain about importing these plain JS modules.
-// @ts-ignore
 import { RaviUtils } from "../libravi/RaviUtils";
-// @ts-ignore
-import { RaviSession, RaviSessionStates, WebRTCSessionParams } from "../libravi/RaviSession";
-// @ts-ignore
+import { RaviSession, RaviSessionStates, WebRTCSessionParams, CustomSTUNandTURNConfig } from "../libravi/RaviSession";
 import { RaviSignalingConnection, RaviSignalingStates } from "../libravi/RaviSignalingConnection";
 import { HiFiAxisUtilities, ourHiFiAxisConfiguration } from "./HiFiAxisConfiguration";
 const pako = require('pako');
@@ -504,7 +500,7 @@ export class HiFiMixerSession {
      * @param webRTCSessionParams - Parameters passed to the RAVI session when opening that session.
      * @returns A Promise that rejects with an error message string upon failure, or resolves with the response from `audionet.init` as a string.
      */
-    async connectToHiFiMixer({ webRTCSessionParams }: { webRTCSessionParams?: WebRTCSessionParams }): Promise<any> {
+    async connectToHiFiMixer({ webRTCSessionParams, customSTUNandTURNConfig }: { webRTCSessionParams?: WebRTCSessionParams, customSTUNandTURNConfig?: CustomSTUNandTURNConfig }): Promise<any> {
 
         if (this._currentHiFiConnectionState === HiFiConnectionStates.Connected && this.mixerInfo["connected"]) {
             let msg = `Already connected! If a reconnect is needed, please hang up and try again.`;
@@ -547,7 +543,7 @@ export class HiFiMixerSession {
         }
 
         try {
-            await this._raviSession.openRAVISession({ signalingConnection: this._raviSignalingConnection, params: webRTCSessionParams });
+            await this._raviSession.openRAVISession({ signalingConnection: this._raviSignalingConnection, params: webRTCSessionParams, customStunAndTurn: customSTUNandTURNConfig });
         } catch (errorOpeningRAVISession) {
             let errMsg = `Couldn't open RAVI session associated with \`${this.webRTCAddress.slice(0, this.webRTCAddress.indexOf("token="))}<token redacted>\`! Error:\n${errorOpeningRAVISession}`;
             if (mixerIsUnavailable) {


### PR DESCRIPTION
Mimics the approach used for setting `webRTCSessionParams`, which are similar.

See also https://github.com/highfidelity/libravi/pull/454 -- this PR pulls in the changes made in that libravi PR (and RAVI release v4.4.0)