### PR TITLE
No ticket: Allow "Failed" connection statuses to transition to "Disconnected"

### DIFF
--- a/tests/smoke/rest.smoke.test.ts
+++ b/tests/smoke/rest.smoke.test.ts
@@ -393,8 +393,13 @@ describe('HiFi API REST Calls', () => {
                 });
                 await sleep(30000);
                 for (let i = 0; i < numberTestUsers; i++) {
-                    if (i === 0) expect(testUsers[i].connectionState).toBe(HiFiConnectionStates.Failed);
-                    else expect(testUsers[i].connectionState).toBe(HiFiConnectionStates.Connected);
+                    if (i === 0) {
+                       expect(testUsers[i].connectionFailed).toBe(true);
+                       expect(testUsers[i].connectionState).toBe(HiFiConnectionStates.Disconnected);
+                    } else {
+                       expect(testUsers[i].connectionFailed).toBe(false);
+                       expect(testUsers[i].connectionState).toBe(HiFiConnectionStates.Connected);
+                    }
                 }
             });
 
@@ -404,7 +409,8 @@ describe('HiFi API REST Calls', () => {
                 });
                 await sleep(30000);
                 for (let i = 0; i < numberTestUsers; i++) {
-                    expect(testUsers[i].connectionState).toBe(HiFiConnectionStates.Failed);
+                    expect(testUsers[i].connectionFailed).toBe(true);
+                    expect(testUsers[i].connectionState).toBe(HiFiConnectionStates.Disconnected);
                 }
             });
         });

--- a/tests/testUtilities/TestUser.ts
+++ b/tests/testUtilities/TestUser.ts
@@ -5,11 +5,13 @@ export type MuteState = "MUTED_FIXED" | "MUTED_NOT_FIXED" | "UNMUTED";
 export class TestUser {
     name: string;
     connectionState: HiFiConnectionStates;
+    connectionFailed: boolean;
     muteState: MuteState;
     communicator: HiFiCommunicator;
 
     constructor(name: string) {
         this.name = name;
+        this.connectionFailed = false;
         this.connectionState = HiFiConnectionStates.Disconnected;
         this.muteState = "UNMUTED";
         this.communicator = new HiFiCommunicator({
@@ -20,6 +22,9 @@ export class TestUser {
 
     onConnectionStateChanged(connectionState: HiFiConnectionStates) {
         this.connectionState = connectionState;
+        if (connectionState === HiFiConnectionStates.Failed) {
+            this.connectionFailed = true;
+        }
     }
 
     onMuteChanged(data: any) {


### PR DESCRIPTION
If the connection ends up explicitly getting closed (which it does, via the library). This PR changes the tests to watch to make sure that a "Failed" status change handler does fire, and that the connection then subsequently goes to "Disconnected". Will also be relevant for work being done as part of HIFI-629.