### PR TITLE
Integration tests fail if no 'safe to test' label

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -28,10 +28,19 @@ jobs:
         continue-on-error: false
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'safe to test') && github.event_name != 'workflow_dispatch' }}
         run: exit 1
+        
+      - name: Configure Build Environment
+        shell: bash
+        id: buildenv
+        run: |
+          if [ ${{ github.event_name }} == "workflow_dispatch" ]; then
+            echo $GITHUB_SHA >> $GITHUB_ENV
+          else
+            echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge" >> $GITHUB_ENV
       
       - uses: actions/checkout@v2
         with:
-          ref: 'refs/pull/${{ github.event.number }}/merge'
+          ref: '${{ env.CHECKOUT_REF }}'
     
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Configure Build Environment
         shell: bash
         id: buildenv
-        run: if [ ${{ github.event_name }} == "workflow_dispatch" ]; then echo ${{ GITHUB_SHA }} >> $GITHUB_ENV; else echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge'" >> $GITHUB_ENV;
+        run: if [ ${{ github.event_name }} == "workflow_dispatch" ]; then echo ${{ github.ref }} >> $GITHUB_ENV; else echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge'" >> $GITHUB_ENV;
       
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -1,4 +1,4 @@
-name: Run-Jest-Unit-Tests
+name: Run-Jest-Integration-Tests
 
 on:
   workflow_dispatch:
@@ -8,21 +8,28 @@ on:
         required: true
         default: api-staging-latest.highfidelity.com
       
-  pull_request:
+  pull_request_target:
     branches:
       - main
       - release
+ 
 
 jobs:
-  Run-Jest-Unit-Tests:
+  Run-Jest-Integration-Tests:
     runs-on: ubuntu-latest
     if: github.event.pusher.name != 'hifibuild' && github.event.pusher.name != 'dependabot'
 
     steps:
       - name: View Commit Author
         run: echo "The last push was made by a user named ${{ github.event.pusher.name }}."
+
+      - name: Check for 'safe to test' label
+        if: "!contains(github.event.pull_request.labels.*.name, 'safe to test')"
+        run: exit 1
       
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
     
       - uses: actions/setup-node@v2
         with:
@@ -31,11 +38,19 @@ jobs:
       - name: Install Modules
         run: npm i
 
-      # Run unit tests
-      - name: Run Jest Unit Tests
+     # Run integration tests
+      - name: Decrypt auth file
+        if: always()
+        run: ./.github/scripts/decryptAuthFile.sh
+        env:
+          TESTING_AUTH_DECRYPTION_KEY: ${{ secrets.TESTING_AUTH_DECRYPTION_KEY }}
+          STACKNAME: ${{ github.event.inputs.stackname || 'api-staging-latest' }}
+        
+      - name: Run Jest Integration Tests
+        if: always()
         shell: bash
         run: |
-          ./node_modules/.bin/jest unit --ci --useStderr 2>&1 | tee testoutput
+          ./node_modules/.bin/jest integration --ci --useStderr 2>&1 | tee testoutput
           ./testfails.sh
 
       # Final testing status for repo

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -39,7 +39,7 @@ jobs:
           echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge'" >> $GITHUB_ENV;
          fi
       
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
         with:
           ref: '${{ env.CHECKOUT_REF }}'
     

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Configure Build Environment
         shell: bash
         id: buildenv
-        run: if [ ${{ github.event_name }} == "workflow_dispatch" ]; then echo ${{ github.ref }} >> $GITHUB_ENV; else echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge'" >> $GITHUB_ENV;
+        run: if [ ${{ github.event_name }} == "workflow_dispatch" ]; then echo "CHECKOUT_REF=${{ github.sha }}" >> $GITHUB_ENV; else echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge'" >> $GITHUB_ENV;
       
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -9,6 +9,7 @@ on:
         default: api-staging-latest.highfidelity.com
       
   pull_request_target:
+  types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
       - release
@@ -24,7 +25,7 @@ jobs:
         run: echo "The last push was made by a user named ${{ github.event.pusher.name }}."
 
       - name: Check for 'safe to test' label
-        if: "!contains(github.event.pull_request.labels.*.name, 'safe to test')"
+        if: "!contains(github.event.pull_request.labels.*.name, 'safe to test')" && github.event_name != 'workflow_dispatch'
         run: exit 1
       
       - uses: actions/checkout@v2

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: View Commit Author
         run: echo "The last push was made by a user named ${{ github.event.pusher.name }}."
 
-      - name: Check for 'safe to test' label
+      - name: Disallow checks on unsafe code
         continue-on-error: false
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'safe to test') && github.event_name != 'workflow_dispatch' }}
         run: exit 1

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -34,9 +34,9 @@ jobs:
         id: buildenv
         run: |
          if [ ${{ github.event_name }} == "workflow_dispatch" ]; then
-          echo "CHECKOUT_REF='${{ github.ref }}'" >> $GITHUB_ENV;
+          echo "CHECKOUT_REF=${{ github.ref }}" >> $GITHUB_ENV;
          else 
-          echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge'" >> $GITHUB_ENV;
+          echo "CHECKOUT_REF=refs/pull/${{ github.event.number }}/merge" >> $GITHUB_ENV;
          fi
       
       - uses: actions/checkout@master

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -39,7 +39,7 @@ jobs:
           echo "CHECKOUT_REF=refs/pull/${{ github.event.number }}/merge" >> $GITHUB_ENV;
          fi
       
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
         with:
           ref: '${{ env.CHECKOUT_REF }}'
     

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Configure Build Environment
         shell: bash
         id: buildenv
-        run: if [ ${{ github.event_name }} == "workflow_dispatch" ]; then echo ${{ github.sha }} >> $GITHUB_ENV; else echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge'" >> $GITHUB_ENV;
+        run: if [ ${{ github.event_name }} == "workflow_dispatch" ]; then echo ${{ GITHUB_SHA }} >> $GITHUB_ENV; else echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge'" >> $GITHUB_ENV;
       
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -31,7 +31,7 @@ jobs:
       
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          'refs/pull/${{ github.event.number }}/merge'
     
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -33,10 +33,7 @@ jobs:
         shell: bash
         id: buildenv
         run: |
-          if [ ${{ github.event_name }} == "workflow_dispatch" ]; then
-            echo $GITHUB_SHA >> $GITHUB_ENV
-          else
-            echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge'" >> $GITHUB_ENV
+          if [ ${{ github.event_name }} == "workflow_dispatch" ]; then echo $GITHUB_SHA >> $GITHUB_ENV; else echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge'" >> $GITHUB_ENV;
       
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Configure Build Environment
         shell: bash
         id: buildenv
-        run: if [ ${{ github.event_name }} == "workflow_dispatch" ]; then echo $GITHUB_SHA >> $GITHUB_ENV; else echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge'" >> $GITHUB_ENV;
+        run: if [ ${{ github.event_name }} == "workflow_dispatch" ]; then echo ${{ github.sha }} >> $GITHUB_ENV; else echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge'" >> $GITHUB_ENV;
       
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -32,7 +32,12 @@ jobs:
       - name: Configure Build Environment
         shell: bash
         id: buildenv
-        run: if [ ${{ github.event_name }} == "workflow_dispatch" ]; then echo "CHECKOUT_REF='${{ github.sha }}'" >> $GITHUB_ENV; else echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge'" >> $GITHUB_ENV;
+        run: |
+         if [ ${{ github.event_name }} == "workflow_dispatch" ]; then
+          echo "CHECKOUT_REF='${{ github.sha }}'" >> $GITHUB_ENV;
+         else 
+          echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge'" >> $GITHUB_ENV;
+         fi
       
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -9,7 +9,7 @@ on:
         default: api-staging-latest.highfidelity.com
       
   pull_request_target:
-  types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
       - release
@@ -25,8 +25,7 @@ jobs:
         run: echo "The last push was made by a user named ${{ github.event.pusher.name }}."
 
       - name: Check for 'safe to test' label
-        if: "!contains(github.event.pull_request.labels.*.name, 'safe to test')" && github.event_name != 'workflow_dispatch'
-        run: exit 1
+        if: contains(github.event.pull_request.labels.*.name, 'safe to test' || github.event_name != 'workflow_dispatch'
       
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Check for 'safe to test' label
         continue-on-error: false
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'safe to test') && "github.event_name != 'workflow_dispatch'" }}
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'safe to test') && github.event_name != 'workflow_dispatch' }}
         run: exit 1
       
       - uses: actions/checkout@v2

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -25,9 +25,9 @@ jobs:
         run: echo "The last push was made by a user named ${{ github.event.pusher.name }}."
 
       - name: Check for 'safe to test' label
-        if: contains(github.event.pull_request.labels.*.name, 'safe to test' || github.event_name != 'workflow_dispatch'
-        run: exit 1
         continue-on-error: false
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'safe to test') && "github.event_name != 'workflow_dispatch'" }}
+        run: exit 1
       
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Check for 'safe to test' label
         if: contains(github.event.pull_request.labels.*.name, 'safe to test' || github.event_name != 'workflow_dispatch'
+        run: exit 1
+        continue-on-error: false
       
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -32,8 +32,7 @@ jobs:
       - name: Configure Build Environment
         shell: bash
         id: buildenv
-        run: |
-          if [ ${{ github.event_name }} == "workflow_dispatch" ]; then echo $GITHUB_SHA >> $GITHUB_ENV; else echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge'" >> $GITHUB_ENV;
+        run: if [ ${{ github.event_name }} == "workflow_dispatch" ]; then echo $GITHUB_SHA >> $GITHUB_ENV; else echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge'" >> $GITHUB_ENV;
       
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -31,7 +31,7 @@ jobs:
       
       - uses: actions/checkout@v2
         with:
-          'refs/pull/${{ github.event.number }}/merge'
+          ref: 'refs/pull/${{ github.event.number }}/merge'
     
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -34,7 +34,7 @@ jobs:
         id: buildenv
         run: |
          if [ ${{ github.event_name }} == "workflow_dispatch" ]; then
-          echo "CHECKOUT_REF='${{ github.sha }}'" >> $GITHUB_ENV;
+          echo "CHECKOUT_REF='${{ github.ref }}'" >> $GITHUB_ENV;
          else 
           echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge'" >> $GITHUB_ENV;
          fi

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Configure Build Environment
         shell: bash
         id: buildenv
-        run: if [ ${{ github.event_name }} == "workflow_dispatch" ]; then echo "CHECKOUT_REF='${{ github.sha }}"' >> $GITHUB_ENV; else echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge'" >> $GITHUB_ENV;
+        run: if [ ${{ github.event_name }} == "workflow_dispatch" ]; then echo "CHECKOUT_REF='${{ github.sha }}'" >> $GITHUB_ENV; else echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge'" >> $GITHUB_ENV;
       
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -36,7 +36,7 @@ jobs:
           if [ ${{ github.event_name }} == "workflow_dispatch" ]; then
             echo $GITHUB_SHA >> $GITHUB_ENV
           else
-            echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge" >> $GITHUB_ENV
+            echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge'" >> $GITHUB_ENV
       
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Configure Build Environment
         shell: bash
         id: buildenv
-        run: if [ ${{ github.event_name }} == "workflow_dispatch" ]; then echo "CHECKOUT_REF=${{ github.sha }}" >> $GITHUB_ENV; else echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge'" >> $GITHUB_ENV;
+        run: if [ ${{ github.event_name }} == "workflow_dispatch" ]; then echo "CHECKOUT_REF='${{ github.sha }}"' >> $GITHUB_ENV; else echo "CHECKOUT_REF='refs/pull/${{ github.event.number }}/merge'" >> $GITHUB_ENV;
       
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -1,13 +1,7 @@
 name: Run-Jest-Unit-Tests
 
 on:
-  workflow_dispatch:
-    inputs:
-      stackname:
-        description: "Host name, i.e. 'api.highfidelity.com', `api-staging-latest.highfidelity.com`, or 'api-pro-east.highfidelity.com'"
-        required: true
-        default: api-staging-latest.highfidelity.com
-      
+  workflow_dispatch:      
   pull_request:
     branches:
       - main


### PR DESCRIPTION
If a PR author is 'hifibuild' or 'dependabot', no tests are required. Otherwise, all tests must pass before a PR can be merged. For these PR's that require testing:

* Unit tests will run automatically on all pull requests. 
* Integration tests will run automatically on all pull requests BUT will fail if no 'safe to test' label has been added.

Running an integration test manually from the Github actions tab will skip the label requirement.
