### PR TITLE
reset before await

### DIFF
--- a/src/diagnostics/diagnostics.ts
+++ b/src/diagnostics/diagnostics.ts
@@ -87,11 +87,11 @@ export class Diagnostics {
     async fire() {
         if (!this.isPrimed()) return;
         const reportString = this.toString();
+        this.reset();
         if (! await this.report(reportString)) {
             this.persist(reportString);
         }
-        this.reset();
-        }
+    }
     noteExplicitApplicationClose() {
         this.explicitApplicationClose = true;
     }


### PR DESCRIPTION
I'm not sure this matters at all in current code, but it came out in testing of https://github.com/highfidelity/hifi-spatial-audio-js/pull/121 that `fire()` introduces an await pause during which other events can call `fire()` before the first call has had a chance to `reset()`.  That causes more than expected number of reports "per session", with the same session id.

The fix is not merely to move `reset()` earlier, but specifically before there is any `await` or `.then()` (but after we gather the report string, of course).