### PR TITLE
Default auto-reconnects to "off"

### DIFF
--- a/src/constants/HiFiConstants.ts
+++ b/src/constants/HiFiConstants.ts
@@ -31,9 +31,9 @@ export class HiFiConstants {
      * See {@link ConnectionRetryAndTimeoutConfig}
      */
     static DEFAULT_CONNECTION_RETRY_AND_TIMEOUT: ConnectionRetryAndTimeoutConfig = {
-        autoRetryInitialConnection: true,
+        autoRetryInitialConnection: false,
         maxSecondsToSpendRetryingInitialConnection: 15,
-        autoRetryOnDisconnect: true,
+        autoRetryOnDisconnect: false,
         maxSecondsToSpendRetryingOnDisconnect: 60,
         pauseBetweenRetriesMS: 500,
         timeoutPerConnectionAttemptMS: 5000


### PR DESCRIPTION
Before releasing the auto-reconnect functionality, it's probably best to turn auto-reconnects "off" by default, for two reasons:

1) Matches existing functionality
2) Avoids the "kick" conflict described in HIFI-630 (cc @bridie-hifi )
