### PR TITLE
HIFI-923 - Allow multiple mixer sessions.

### DIFF
--- a/src/classes/HiFiCommunicator.ts
+++ b/src/classes/HiFiCommunicator.ts
@@ -945,7 +945,7 @@ export class HiFiCommunicator {
         this._inputAudioMediaStreamIsStereo = isStereo;
         let retval = await this._mixerSession.setRAVIInputAudio(newInputAudioMediaStream, isStereo);    
         if (retval) {
-            retval = retval &&  await this._secondaryMixerSession.setRAVIInputAudio(newInputAudioMediaStream, isStereo);
+            retval = await this._secondaryMixerSession.setRAVIInputAudio(newInputAudioMediaStream, isStereo);
         }
         if (!retval){
             HiFiLogger.warn(`Error trying to setRAVIInputAudio on this._mixerSession`);

--- a/src/classes/HiFiCommunicator.ts
+++ b/src/classes/HiFiCommunicator.ts
@@ -793,7 +793,7 @@ export class HiFiCommunicator {
         // change the current state to the new state and call the user's handler.
         if (newState !== this._currentHiFiConnectionState) {
             this._currentHiFiConnectionState = newState;
-            if (!secondary && this.onConnectionStateChanged) {
+            if (this.onConnectionStateChanged) {
                 this.onConnectionStateChanged(this._currentHiFiConnectionState, message);
             }
         }
@@ -1416,7 +1416,7 @@ export class HiFiCommunicator {
         }
 
         let timeoutPerConnectionAttempt = this._connectionRetryAndTimeoutConfig.timeoutPerConnectionAttemptMS;
-        // Kick off the connection attempt. This returns a boolean, but any actual success or failure
+        // Kick off the connection attempt. Any actual success or failure
         // gets handled by the _manageConnection callback handler. (Note that calls to our _connectToHiFiMixer()
         // method get handled entirely by callback-initiated retry code, so we should never get here unless
         // a callback asked us to do it.)

--- a/src/classes/HiFiCommunicator.ts
+++ b/src/classes/HiFiCommunicator.ts
@@ -611,7 +611,7 @@ export class HiFiCommunicator {
                  * They should always kick off a new connection attempt, UNLESS the current state is already "Connected".
                  */
                 if (this._currentHiFiConnectionState !== HiFiConnectionStates.Connected) {
-                    HiFiLogger.log(`_manageConnection: kicking off connection attempt.`);
+                    HiFiLogger.log(`_manageConnection: kicking off connection attempt: ${newState}.`);
                     this._updateStateAndCallUserStateChangeHandler(newState, message, secondary);
                     this._connectToHiFiMixer();
                 } else {

--- a/src/classes/HiFiCommunicator.ts
+++ b/src/classes/HiFiCommunicator.ts
@@ -17,6 +17,20 @@ import { HiFiCoordinateFrameUtil } from "../utilities/HiFiCoordinateFrameUtil";
 import { HiFiHandedness, WorldFrameConfiguration } from "./HiFiAxisConfiguration";
 import { HiFiMixerSession, SetOtherUserGainForThisConnectionResponse, SetOtherUserGainsForThisConnectionResponse, OnMuteChangedCallback } from "./HiFiMixerSession";
 import { AvailableUserDataSubscriptionComponents, UserDataSubscription } from "./HiFiUserDataSubscription";
+import { RaviUtils } from "../libravi/RaviUtils";
+
+const isBrowser = typeof window !== 'undefined';
+// Since we're initializing a MediaStream, we need to
+// do it using the correct cross-platform class (node or browser)
+let xMediaStream = isBrowser && window.MediaStream;
+if (!isBrowser) {
+    try {
+        xMediaStream = require('wrtc').MediaStream;
+    } catch (e) {
+        ; // Remains falsey. Don't report, don't log
+    }
+}
+
 
 /**
  * When the state of the connection to the High Fidelity Audio Server changes, the new state will be one of these values.
@@ -199,6 +213,11 @@ export class HiFiCommunicator {
     // This is usually the `MediaStream` associated with a user's audio input device,
     // but it could be any `MediaStream`.
     private _inputAudioMediaStream: MediaStream;
+    
+    private _inputAudioMediaStreamIsStereo: boolean;
+
+    // This is usually the `MediaStream` associated with a user's audio output device
+    private _outputAudioMediaStream: MediaStream;
 
     // These next two member variables are used for keeping track of what to send to the mixer.
     // The client only sends data that the mixer doesn't already know about.
@@ -238,6 +257,7 @@ export class HiFiCommunicator {
 
     // This contains data dealing with the mixer session, such as the RAVI session, WebRTC address, etc.
     private _mixerSession: HiFiMixerSession;
+    private _secondaryMixerSession: HiFiMixerSession;
 
     private _webRTCSessionParams?: WebRTCSessionParams;
     private _customSTUNandTURNConfig?: CustomSTUNandTURNConfig;
@@ -249,6 +269,10 @@ export class HiFiCommunicator {
     // These store a reference to the `resolve()` and `reject()` methods until they need to be called.
     private _resolveOpen: Function;
     private _rejectOpen: Function;
+    
+    // uniquely identify this session
+    private _visitId: string;
+    
 
     /**
      * If the World coordinate system is NOT compatible with the HiFi coordindate frame used by the mixer              
@@ -309,6 +333,9 @@ export class HiFiCommunicator {
         onMuteChanged?: OnMuteChangedCallback,
         connectionRetryAndTimeoutConfig?: ConnectionRetryAndTimeoutConfig
     } = {}) {
+        
+        this._visitId = RaviUtils.createUUID();
+        
         // If user passed in their own stun/turn config, make sure it matches our interface (ish).
         // (I do so wish that TypeScript could just do this for us based on the interface definition, but it seems that it can not.)
         if (customSTUNandTURNConfig) {
@@ -373,6 +400,8 @@ export class HiFiCommunicator {
             }
         }
 
+        this._outputAudioMediaStream = new xMediaStream();
+
         this._mixerSession = new HiFiMixerSession({
             "userDataStreamingScope": userDataStreamingScope,
             "onUserDataUpdated": (data: Array<ReceivedHiFiAudioAPIData>) => { this._handleUserDataUpdates(data); },
@@ -380,10 +409,23 @@ export class HiFiCommunicator {
             "onConnectionStateChanged": (state: HiFiConnectionStates, message: HiFiConnectionAttemptResult) => { this._manageConnection(state, message); },
             "onMuteChanged": onMuteChanged,
             "getUserFacingConnectionState": this.getConnectionState.bind(this),
-            "coordFrameUtil": this._coordFrameUtil
+            "coordFrameUtil": this._coordFrameUtil,
+            "onTransitionRequested": () => { this._onTransitionRequested(); },
+            "onTransition": () => { this._onTransition(); },
+            "visitId": this._visitId,
+            "outputAudioMediaStream": this._outputAudioMediaStream
+            
+        });
+        
+        this._secondaryMixerSession = new HiFiMixerSession({
+            "onConnectionStateChanged": (state: HiFiConnectionStates, message: HiFiConnectionAttemptResult) => { this._manageConnection(state, message, true); },
+            "visitId": this._visitId,
+            "onReadyForTransition": () => { this._onReadyForTransition(); },
+            "outputAudioMediaStream": this._outputAudioMediaStream
         });
 
         this._inputAudioMediaStream = undefined;
+        this._inputAudioMediaStreamIsStereo = false;
 
         this._currentHiFiAudioAPIData = new HiFiAudioAPIData();
 
@@ -483,6 +525,7 @@ export class HiFiCommunicator {
         signalingPort = signalingPort ? signalingPort : HiFiConstants.DEFAULT_PROD_HIGH_FIDELITY_PORT;
         let webRTCSignalingAddress = `wss://${signalingHostURLSafe}:${signalingPort}/?token=`;
         this._mixerSession.webRTCAddress = `${webRTCSignalingAddress}${hifiAuthJWT}`;
+        this._secondaryMixerSession.webRTCAddress = `${webRTCSignalingAddress}${hifiAuthJWT}`;
         HiFiLogger.log(`Using WebRTC Signaling Address:\n${webRTCSignalingAddress}<token redacted>`);
 
         // When making the initial connection, this connection method's promise shouldn't
@@ -556,7 +599,7 @@ export class HiFiCommunicator {
      * @param message An optional message to include as part of the state change. This will be communicated
      * to users as part of the Reject or Resolve of the connection opening Promise.
      */
-    private _manageConnection(newState: HiFiConnectionStates, message?: HiFiConnectionAttemptResult): void {
+    private _manageConnection(newState: HiFiConnectionStates, message?: HiFiConnectionAttemptResult, secondary?: boolean): void {
         switch (newState) {
             case HiFiConnectionStates.Connecting:
             case HiFiConnectionStates.Reconnecting:
@@ -569,7 +612,7 @@ export class HiFiCommunicator {
                  */
                 if (this._currentHiFiConnectionState !== HiFiConnectionStates.Connected) {
                     HiFiLogger.log(`_manageConnection: kicking off connection attempt.`);
-                    this._updateStateAndCallUserStateChangeHandler(newState, message);
+                    this._updateStateAndCallUserStateChangeHandler(newState, message, secondary);
                     this._connectToHiFiMixer();
                 } else {
                     HiFiLogger.warn(`_manageConnection called for ${newState} -- but already connected; taking no action.`);
@@ -587,7 +630,7 @@ export class HiFiCommunicator {
                 this._retryTimerInProgress = null;
                 this._failureNotificationPending = undefined; // No need to let them know if we failed earlier; everything's OK now!
                 // Finally, tell the user ("message" should be set to audionet.init result by the mixer change handler)
-                this._updateStateAndCallUserStateChangeHandler(newState, message);
+                this._updateStateAndCallUserStateChangeHandler(newState, message, secondary);        
                 return;
 
             case HiFiConnectionStates.Disconnecting:
@@ -595,7 +638,7 @@ export class HiFiCommunicator {
                  * The Disconnecting state is only ever set explicitly, when the `disconnectFromHiFiAudioAPIServer()` method is called,
                  * and is just used to track the fact that the user initiated the disconnection.
                  */
-                this._updateStateAndCallUserStateChangeHandler(newState, message);
+                this._updateStateAndCallUserStateChangeHandler(newState, message, secondary);
                 return;
 
             case HiFiConnectionStates.Failed:
@@ -618,6 +661,17 @@ export class HiFiCommunicator {
                  * then this is a normal and expected disconnect, and the customer's stateChangeHandler should be called
                  * and we're all done. However, if the current state is something else, we may want to retry.
                  */
+                 
+                if (secondary) {
+                    if (!isBrowser) {
+                        // for some unknown reason, wrtc stops streaming microphone audio on the
+                        // primary session when the secondary session disconnects.  (non-browser only)
+                        // So, we reset the input audio media stream on the primary.
+                        this._mixerSession.setRAVIInputAudio(this._inputAudioMediaStream, this._inputAudioMediaStreamIsStereo);    
+                    }                     
+                    return;
+                }
+                 
                 if (this._retryTimerInProgress) {
                     HiFiLogger.log("_manageConnection: Timer active; continuing to retry connection");
 
@@ -628,7 +682,7 @@ export class HiFiCommunicator {
                                 this._currentHiFiConnectionState !== HiFiConnectionStates.Reconnecting) {
                         HiFiLogger.warn(`_manageConnection handling reconnection, but encountered unexpected state ${this._currentHiFiConnectionState}; will attempt to reconnect, but please contact High Fidelity and report this message`);
                         // Fix the state; "Reconnecting" seems the best option at this point.
-                        this._updateStateAndCallUserStateChangeHandler(HiFiConnectionStates.Reconnecting, message);
+                        this._updateStateAndCallUserStateChangeHandler(HiFiConnectionStates.Reconnecting, message, secondary);
                     }
                     // Catch our breath (the "pauseBetweenRetriesMS" setting), and then retry again
                     setTimeout(() => {
@@ -671,10 +725,10 @@ export class HiFiCommunicator {
                     // calling the customer's state change handler. Let them know about a failure if it
                     // had happened, then tell them about the disconnection.
                     if (this._failureNotificationPending) {
-                        this._updateStateAndCallUserStateChangeHandler(HiFiConnectionStates.Failed, this._failureNotificationPending);
-                        this._updateStateAndCallUserStateChangeHandler(HiFiConnectionStates.Disconnected, this._failureNotificationPending);
+                        this._updateStateAndCallUserStateChangeHandler(HiFiConnectionStates.Failed, this._failureNotificationPending, secondary);
+                        this._updateStateAndCallUserStateChangeHandler(HiFiConnectionStates.Disconnected, this._failureNotificationPending, secondary);
                     } else {
-                        this._updateStateAndCallUserStateChangeHandler(HiFiConnectionStates.Disconnected, message);
+                        this._updateStateAndCallUserStateChangeHandler(HiFiConnectionStates.Disconnected, message, secondary);
                     }
                     this._failureNotificationPending = undefined;
                     return;
@@ -690,7 +744,7 @@ export class HiFiCommunicator {
 
                     if (this._currentHiFiConnectionState === HiFiConnectionStates.Connected) {
                         // Set the state to "Reconnecting" if it's the first failure from a connected state.
-                        this._updateStateAndCallUserStateChangeHandler(HiFiConnectionStates.Reconnecting, message);
+                        this._updateStateAndCallUserStateChangeHandler(HiFiConnectionStates.Reconnecting, message, secondary);
                         setTimeout(() => {
                                 this._manageConnection(HiFiConnectionStates.Reconnecting);
                         }, this._connectionRetryAndTimeoutConfig.pauseBetweenRetriesMS);
@@ -709,7 +763,7 @@ export class HiFiCommunicator {
                  * "Unavailable" means there isn't any room on the server; this is itself a
                  * "failure" and "disconnected" state and so no additional state changes should get called after this.
                  */
-                this._updateStateAndCallUserStateChangeHandler(newState, message);
+                this._updateStateAndCallUserStateChangeHandler(newState, message, secondary);
                 return;
 
             default:
@@ -725,7 +779,10 @@ export class HiFiCommunicator {
      * All updates to `this._currentHiFiConnectionState` should go through this method
      * unless there's a really good reason (e.g. `_cancelRetriedConnectionAttempts`)
      */
-    private _updateStateAndCallUserStateChangeHandler(newState: HiFiConnectionStates, message?: HiFiConnectionAttemptResult): void {
+    private _updateStateAndCallUserStateChangeHandler(newState: HiFiConnectionStates, message?: HiFiConnectionAttemptResult, secondary?: boolean): void {
+        if (secondary) {
+            return;
+        }
         if (newState === HiFiConnectionStates.Connected) {
             // Always reset last transmitted, and transmit current data as soon as we connect, just to be sure
             this._lastTransmittedHiFiAudioAPIData = new HiFiAudioAPIData();
@@ -736,7 +793,7 @@ export class HiFiCommunicator {
         // change the current state to the new state and call the user's handler.
         if (newState !== this._currentHiFiConnectionState) {
             this._currentHiFiConnectionState = newState;
-            if (this.onConnectionStateChanged) {
+            if (!secondary && this.onConnectionStateChanged) {
                 this.onConnectionStateChanged(this._currentHiFiConnectionState, message);
             }
         }
@@ -795,6 +852,7 @@ export class HiFiCommunicator {
 
         this._lastTransmittedHiFiAudioAPIData = new HiFiAudioAPIData();
 
+        await this._secondaryMixerSession.disconnectFromHiFiMixer();
         return this._mixerSession.disconnectFromHiFiMixer();
     }
 
@@ -861,11 +919,7 @@ export class HiFiCommunicator {
      * @returns The final mixed audio `MediaStream` coming from the High Fidelity Audio Server.
      */
     getOutputAudioMediaStream(): MediaStream {
-        if (this._mixerSession) {
-            return this._mixerSession.getOutputAudioMediaStream();
-        } else {
-            return null;
-        }
+        return this._outputAudioMediaStream;
     }
 
     /**
@@ -887,10 +941,13 @@ export class HiFiCommunicator {
      * @returns `true` if the new `MediaStream` was successfully set, `false` otherwise.
      */
     async setInputAudioMediaStream(newInputAudioMediaStream: MediaStream, isStereo: boolean = false): Promise<boolean> {
-        const retval = await this._mixerSession.setRAVIInputAudio(newInputAudioMediaStream, isStereo);
+        this._inputAudioMediaStream = newInputAudioMediaStream;
+        this._inputAudioMediaStreamIsStereo = isStereo;
+        let retval = await this._mixerSession.setRAVIInputAudio(newInputAudioMediaStream, isStereo);    
         if (retval) {
-            this._inputAudioMediaStream = newInputAudioMediaStream;
-        } else {
+            retval = retval &&  await this._secondaryMixerSession.setRAVIInputAudio(newInputAudioMediaStream, isStereo);
+        }
+        if (!retval){
             HiFiLogger.warn(`Error trying to setRAVIInputAudio on this._mixerSession`);
         }
         return retval;
@@ -1149,6 +1206,10 @@ export class HiFiCommunicator {
             // The function will return the raw data that it sent to the mixer.
             let transmitRetval = this._mixerSession._transmitHiFiAudioAPIDataToServer(this._currentHiFiAudioAPIData, this._lastTransmittedHiFiAudioAPIData);
             if (transmitRetval.success) {
+                // send data to secondary session if it's connected.
+                if(this._secondaryMixerSession.isConnected()) {
+                    this._secondaryMixerSession._transmitHiFiAudioAPIDataToServer(this._currentHiFiAudioAPIData, this._lastTransmittedHiFiAudioAPIData);
+                }
                 // Now we have to update our "last transmitted" `HiFiAudioAPIData` object
                 // to contain the data that we just transmitted.
                 this._updateLastTransmittedHiFiAudioAPIData(this._currentHiFiAudioAPIData);
@@ -1336,5 +1397,55 @@ export class HiFiCommunicator {
 
         HiFiLogger.log(`Adding new User Data Subscription:\n${JSON.stringify(newSubscription)}`);
         this._userDataSubscriptions.push(newSubscription);
+    }
+    
+    /**
+     * Connects to the secondary mixer in preparation to move seamlessly to that mixer.
+     */
+    private _onTransitionRequested() {
+        HiFiLogger.debug("Transition requested.");
+        if (!this._secondaryMixerSession || !this._secondaryMixerSession.webRTCAddress) {
+            this._manageConnection(HiFiConnectionStates.Failed, { success: false, error: "_secondaryMixerSession misconfigured" }, true);
+            return;
+        }
+        // This should never get called unless we are reasonably certain that the session is
+        // NOT connected, but just in case.
+        if (this._secondaryMixerSession.isConnected()) {
+            let msg = `Secondary Mixer Session is already connected!`;
+            throw new Error(msg);
+        }
+
+        let timeoutPerConnectionAttempt = this._connectionRetryAndTimeoutConfig.timeoutPerConnectionAttemptMS;
+        // Kick off the connection attempt. This returns a boolean, but any actual success or failure
+        // gets handled by the _manageConnection callback handler. (Note that calls to our _connectToHiFiMixer()
+        // method get handled entirely by callback-initiated retry code, so we should never get here unless
+        // a callback asked us to do it.)
+        HiFiLogger.debug("Connecting to secondary mixer.");
+        this._secondaryMixerSession.connectToHiFiMixer({ webRTCSessionParams: this._webRTCSessionParams,
+                                                         customSTUNandTURNConfig: this._customSTUNandTURNConfig,
+                                                         timeout: timeoutPerConnectionAttempt,
+                                                         initData: this._currentHiFiAudioAPIData });   
+    }
+
+    /**
+     * Sends a audionet.transition-ready to the primary mixer.
+     */
+    private _onReadyForTransition() {
+        this._mixerSession.transitionReady();
+    }
+
+    /**
+     * Switches microphone and data streaming to the secondary mixer, and makes that mixer
+     * the primary mixer.
+     */
+    private async _onTransition() {
+        HiFiLogger.debug("Transitioning.");
+        let primaryMixerSession = this._mixerSession;
+        let secondaryMixerSession = this._secondaryMixerSession;
+        await primaryMixerSession.transitionToSecondarySession(secondaryMixerSession);
+        this._mixerSession = secondaryMixerSession;
+        this._secondaryMixerSession = primaryMixerSession;
+
+        primaryMixerSession.transitionComplete();
     }
 }

--- a/src/classes/HiFiMixerSession.ts
+++ b/src/classes/HiFiMixerSession.ts
@@ -344,8 +344,6 @@ export class HiFiMixerSession {
         this._currentDataToTransmitToServer = new HiFiAudioAPIData();
         if (visitId) {
             this._visitId = visitId;
-        } else {
-            RaviUtils.createUUID();
         }
 
         RaviUtils.setDebug(false);
@@ -1115,11 +1113,10 @@ export class HiFiMixerSession {
 
         if (streamController && streamController.getAudioStream()) {
             raviAudioTracks = streamController.getAudioStream().getAudioTracks();
-        }
-
-        if (raviAudioTracks) {
-            HiFiLogger.log(`Setting this._outputAudioMediaStream tracks to the current RAVI audio tracks.`);
-            raviAudioTracks.forEach(f => { this._outputAudioMediaStream.addTrack(f)});
+            if (raviAudioTracks) {
+                HiFiLogger.log(`Setting this._outputAudioMediaStream tracks to the current RAVI audio tracks.`);
+                raviAudioTracks.forEach(f => { this._outputAudioMediaStream.addTrack(f)});
+            }
         }
     }
     /**
@@ -1472,19 +1469,22 @@ export class HiFiMixerSession {
 
         let oldPeers: any = {};
         for (const mixerPeerKey of Object.keys(this._mixerPeerKeyToStateCacheDict)) {
-            oldPeers[this._mixerPeerKeyToStateCacheDict[mixerPeerKey].hashedVisitID] = this._mixerPeerKeyToStateCacheDict[mixerPeerKey];
+            let value = this._mixerPeerKeyToStateCacheDict[mixerPeerKey];
+            oldPeers[value.hashedVisitID] = value;
         }
         for (const mixerPeerKey of Object.keys(secondarySession._mixerPeerKeyToStateCacheDict)) {
-            delete oldPeers[secondarySession._mixerPeerKeyToStateCacheDict[mixerPeerKey].hashedVisitID];
-            allNewUserData.push(secondarySession._mixerPeerKeyToStateCacheDict[mixerPeerKey]);
+            let value = secondarySession._mixerPeerKeyToStateCacheDict[mixerPeerKey];
+            delete oldPeers[value.hashedVisitID];
+            allNewUserData.push(value);
         }
         
         for (const hashedVisitID of Object.keys(oldPeers)) {
             let deletedUserData = new ReceivedHiFiAudioAPIData({
                 hashedVisitID: hashedVisitID
             });
-            if (oldPeers[hashedVisitID].providedUserID) {
-                deletedUserData.providedUserID = oldPeers[hashedVisitID].providedUserID;
+            let username = oldPeers[hashedVisitID].providedUserID;
+            if (username) {
+                deletedUserData.providedUserID = username;
             }
             allDeletedUserData.push(deletedUserData);
         }

--- a/src/classes/HiFiMixerSession.ts
+++ b/src/classes/HiFiMixerSession.ts
@@ -18,18 +18,6 @@ import { RaviSignalingConnection, RaviSignalingStates } from "../libravi/RaviSig
 import { Diagnostics } from "../diagnostics/diagnostics";
 import pako from 'pako'
 
-const isBrowser = typeof window !== 'undefined';
-// Since we're initializing a MediaStream, we need to
-// do it using the correct cross-platform class (node or browser)
-let xMediaStream = isBrowser && window.MediaStream;
-if (!isBrowser) {
-    try {
-        xMediaStream = require('wrtc').MediaStream;
-    } catch (e) {
-        ; // Remains falsey. Don't report, don't log
-    }
-}
-
 const INIT_TIMEOUT_MS = 5000;
 const PERSONAL_VOLUME_ADJUST_TIMEOUT_MS = 5000;
 
@@ -174,6 +162,9 @@ export class HiFiMixerSession {
      */
     private _mixerPeerKeyToStateCacheDict: any;
 
+
+    private _inputAudioMediaStream: MediaStream;
+
     /**
      * We will track whether or not the input stream is stereo, so that
      * we can advise the server to mix it appropriately
@@ -184,6 +175,7 @@ export class HiFiMixerSession {
     private _lastSuccessfulInputAudioMutedValue: boolean;
 
     private onMuteChanged: OnMuteChangedCallback;
+
 
     /**
      * A MediaStream that persists across reconnection attempts; we add the
@@ -223,6 +215,24 @@ export class HiFiMixerSession {
      * This function is called when the "connection state" changes.
      */
     onConnectionStateChanged: ConnectionStateChangeHandler;
+
+    /**
+     * This function is called when the mixer need to pass us off to another mixer
+     * as part of autoscaling.  It indicates the secondary connections should connect.
+     */
+    onTransitionRequested: Function;
+
+    /**
+     * This function is called when the communicator should start streaming microphone data
+     * to the new primary mixer and should start receiving streaming data from the
+     * new mixer as part of autoscaling.
+     */
+    onTransition: Function;
+    
+    /**
+     * Tell the HiFiCommunicator to send an audionet.transition-ready on the primary mixer
+     */
+    onReadyForTransition: Function;
 
     /**
      * If the World coordinate system is NOT compatible with the HiFi coordindate frame used by the mixer
@@ -266,6 +276,7 @@ export class HiFiMixerSession {
     private _getUserFacingConnectionState: Function;
     private _raviDiagnostics: Diagnostics;
     private _hifiDiagnostics: Diagnostics;
+    private _visitId: string;
 
     /**
      * 
@@ -293,7 +304,12 @@ export class HiFiMixerSession {
         onConnectionStateChanged,
         onMuteChanged,
         getUserFacingConnectionState,
-        coordFrameUtil
+        coordFrameUtil,
+        onTransitionRequested,
+        onTransition,
+        onReadyForTransition,
+        visitId,
+        outputAudioMediaStream
     }: {
         userDataStreamingScope?: HiFiUserDataStreamingScopes,
         onUserDataUpdated?: Function,
@@ -301,7 +317,12 @@ export class HiFiMixerSession {
         onConnectionStateChanged?: ConnectionStateChangeHandler,
         onMuteChanged?: OnMuteChangedCallback,
         getUserFacingConnectionState?: Function,
-        coordFrameUtil?: HiFiCoordinateFrameUtil
+        coordFrameUtil?: HiFiCoordinateFrameUtil,
+        onTransitionRequested?: Function,
+        onTransition?: Function,
+        onReadyForTransition?: Function,
+        visitId?: string,
+        outputAudioMediaStream?: MediaStream
     }) {
         this.webRTCAddress = undefined;
         this.userDataStreamingScope = userDataStreamingScope;
@@ -313,6 +334,15 @@ export class HiFiMixerSession {
         this._getUserFacingConnectionState = getUserFacingConnectionState;
         this._disableReconnect = false;
         this._coordFrameUtil = coordFrameUtil;
+        this.onTransitionRequested = onTransitionRequested;
+        this.onTransition = onTransition;
+        this.onReadyForTransition = onReadyForTransition;
+        this._inputAudioMediaStream = undefined;
+        if (visitId) {
+            this._visitId = visitId;
+        } else {
+            RaviUtils.createUUID();
+        }
 
         RaviUtils.setDebug(false);
 
@@ -324,8 +354,7 @@ export class HiFiMixerSession {
 
         this.onConnectionStateChanged = onConnectionStateChanged;
 
-        // Create an empty output media stream that will persist across reconnects
-        this._outputAudioMediaStream = new xMediaStream();
+        this._outputAudioMediaStream = outputAudioMediaStream;
 
         this._tryingToConnect = false;
         this._resetMixerInfo();
@@ -347,7 +376,7 @@ export class HiFiMixerSession {
             let initData = {
                 primary: true,
                 // The mixer will hash this randomly-generated UUID, then disseminate it to all clients via `peerData.e`.
-                visit_id: this._raviSession.getUUID(),
+                visit_id: this._visitId,
                 session: this._raviSession.getUUID(), // Still required for old mixers. Will eventually go away.
                 streaming_scope: this.userDataStreamingScope,
                 is_input_stream_stereo: this._inputAudioMediaStreamIsStereo
@@ -603,7 +632,6 @@ export class HiFiMixerSession {
                 if (!Array.isArray(instruction) || !instruction.length) {
                     continue;
                 }
-
                 let instructionName = instruction[0];
                 let instructionArguments = instruction.slice(1);
                 if (instructionName === "mute") {
@@ -617,11 +645,15 @@ export class HiFiMixerSession {
                         this._setMutedByAdmin(shouldBeMuted, MuteReason.ADMIN);
                     }
                 } else if (instructionName === "terminate") {
-                    // all reasons for termination currently should result in a disconnect
-                    // so that the client doesn't try to automatically reconnect.  Reasons
-                    // will be either kick or user timeout.
-                    this._disableReconnect = true;
+                    if (instructionArguments[0] === "terminate" ||
+                        instructionArguments[0] === "transition") {
+                        this._disableReconnect = true;
+                    }
                     this._disconnectFromHiFiMixer();
+                } else if (instructionName === "transition-requested") {
+                    this._onTransitionRequested();
+                } else if (instructionName === "transition") {
+                    this._onTransition();
                 }
             }
         }
@@ -696,6 +728,7 @@ export class HiFiMixerSession {
             });
         })
         .then((value) => {
+            this._copyAudioTracksFromRavi();           
             HiFiLogger.log(`Session open; running audionet.init`);
             return this.promiseToRunAudioInit(initData)
             .catch((errorRunningAudionetInit) => {
@@ -705,7 +738,7 @@ export class HiFiMixerSession {
         })
         .then((value) => {
             HiFiLogger.log(`audionet.init run; calling state change handler for connected`);
-            this._onConnectionStateChange(HiFiConnectionStates.Connected, value);
+            return this._onConnectionStateChange(HiFiConnectionStates.Connected, value);            
         })
         .then((value) => {
             // We're done with the connection process and can now set the state change handlers
@@ -716,6 +749,7 @@ export class HiFiMixerSession {
             this._raviSession.addStateChangeHandler(this.onRAVISessionStateChanged);
         })
         .catch((error) => {
+            HiFiLogger.warn(error);
             // No matter what happens up there, we want to go to a failed state
             // and pass along the error message. `this._onConnectionStateChange`
             // will disconnect and clean up for us.
@@ -781,6 +815,7 @@ export class HiFiMixerSession {
      * @param isStereo - `true` if the input stream should be treated as stereo. Defaults to `false`.
      * @returns `true` if the new stream was successfully set; `false` otherwise.
      */
+
     async setRAVIInputAudio(inputAudioMediaStream: MediaStream, isStereo: boolean = false): Promise<boolean> {
 
         let retval = false;
@@ -790,7 +825,11 @@ export class HiFiMixerSession {
                 HiFiLogger.warn(`Couldn't set input audio on _raviSession.streamController: No \`streamController\`!`);
                 retval = false;
             } else {
-                streamController.setInputAudio(inputAudioMediaStream, isStereo);
+                if (inputAudioMediaStream) {
+                    streamController.setInputAudio(inputAudioMediaStream.clone(), isStereo);
+                } else {
+                    streamController.setInputAudio(null, isStereo);
+                }
                 HiFiLogger.log(`Successfully set input audio on _raviSession.streamController!`);
                 retval = true;
             }
@@ -807,6 +846,7 @@ export class HiFiMixerSession {
                     let audionetInitResponse;
                     try {
                         this._inputAudioMediaStreamIsStereo = isStereo;
+                    this._inputAudioMediaStream = inputAudioMediaStream;
                         audionetInitResponse = await this.promiseToRunAudioInit();
                     } catch (initError) {
                         // If this goes wrong, do we actually care all that much?
@@ -820,6 +860,7 @@ export class HiFiMixerSession {
                     // If we haven't already connected, it'll just pick up the right stereo value when we
                     // call it the first time.
                     this._inputAudioMediaStreamIsStereo = isStereo;
+                    this._inputAudioMediaStream = inputAudioMediaStream;
                 }
             }
         }
@@ -1002,17 +1043,23 @@ export class HiFiMixerSession {
      * @param state
      */
     async _onConnectionStateChange(state: HiFiConnectionStates, result: HiFiConnectionAttemptResult): Promise<void> {
+        
         if (this.getCurrentHiFiConnectionState() !== state) {
             if (this.onConnectionStateChanged) {
                 this.onConnectionStateChanged(state, result);
             }
-            if (state === HiFiConnectionStates.Connected) {
-                this._raviDiagnostics.prime(this.mixerInfo.visit_id_hash);
-                this._hifiDiagnostics.prime(this.mixerInfo.visit_id_hash);
-                this._copyAudioTracksFromRavi();
-            } else {
-                this._hifiDiagnostics.fire();
+        }
+        
+        if (state === HiFiConnectionStates.Connected) {
+            this._raviDiagnostics.prime(this.mixerInfo.visit_id_hash);
+            this._hifiDiagnostics.prime(this.mixerInfo.visit_id_hash);
+            if (this.onReadyForTransition) {
+                this.onReadyForTransition();
             }
+        } else if (state === HiFiConnectionStates.Disconnected) {
+            this._hifiDiagnostics.fire();
+        } else {
+            this._hifiDiagnostics.fire();
         }
 
         if (state === HiFiConnectionStates.Failed) {
@@ -1049,7 +1096,6 @@ export class HiFiMixerSession {
      * and replaces them with the tracks that are currently on the RAVI stream controller.
      */
     _copyAudioTracksFromRavi() {
-        let currentAudioTracks = this._outputAudioMediaStream.getAudioTracks();
         let raviAudioTracks = undefined;
         let streamController = this._raviSession.getStreamController();
 
@@ -1058,11 +1104,28 @@ export class HiFiMixerSession {
         }
 
         if (raviAudioTracks) {
-            HiFiLogger.log(`Resetting this._outputAudioMediaStream tracks to the current RAVI audio tracks.`);
-            currentAudioTracks.forEach(f => this._outputAudioMediaStream.removeTrack(f));
-            raviAudioTracks.forEach(f => this._outputAudioMediaStream.addTrack(f));
+            HiFiLogger.log(`Setting this._outputAudioMediaStream tracks to the current RAVI audio tracks.`);
+            raviAudioTracks.forEach(f => { this._outputAudioMediaStream.addTrack(f)});
         }
     }
+    /**
+     * This method is meant to be called once the connection state reaches "Disconnected".
+     * It removes any existing tracks from the persistent `this._outputAudioMediaStream.`
+     */
+    _removeAudioTracksFromRavi() {
+        let raviAudioTracks = undefined;
+        let streamController = this._raviSession.getStreamController();
+
+        if (streamController && streamController.getAudioStream()) {
+            raviAudioTracks = streamController.getAudioStream().getAudioTracks();
+        }
+
+        if (raviAudioTracks) {
+            HiFiLogger.log(`Removing this._outputAudioMediaStream tracks to the current RAVI audio tracks.`);
+            raviAudioTracks.forEach(f => this._outputAudioMediaStream.removeTrack(f));
+        }
+    }
+
     /**
      * Fires when the RAVI Session State changes.
      * @param event
@@ -1075,16 +1138,19 @@ export class HiFiMixerSession {
             case RaviSessionStates.CONNECTED:
                 HiFiLogger.log(`RaviSession connected; waiting for results of audionet.init`);
                 this._copyAudioTracksFromRavi();
+                await this.setRAVIInputAudio(this._inputAudioMediaStream, this._inputAudioMediaStreamIsStereo);
                 break;
             case RaviSessionStates.CLOSED:
+                this._removeAudioTracksFromRavi();
                 message = "RaviSession has been closed; connection to High Fidelity servers has been disconnected";
-                this._onConnectionStateChange(HiFiConnectionStates.Disconnected, { success: true, error: message, disableReconnect: this._disableReconnect });
+                this._onConnectionStateChange(HiFiConnectionStates.Disconnected, { success: true, error: message, disableReconnect: this._disableReconnect });     
                 break;
             case RaviSessionStates.DISCONNECTED:
             case RaviSessionStates.FAILED:
                 message = "RaviSession has disconnected unexpectedly";
                 this._onConnectionStateChange(HiFiConnectionStates.Failed, { success: false, error: message, disableReconnect: this._disableReconnect });
                 try {
+                    this._removeAudioTracksFromRavi();
                     await this._disconnectFromHiFiMixer();
                 } catch (errorClosing) {
                     HiFiLogger.log(`Error encountered while trying to close the connection. Error:\n${RaviUtils.safelyPrintable(errorClosing)}`);
@@ -1316,5 +1382,105 @@ export class HiFiMixerSession {
             "connected": false,
         };
         this._mixerPeerKeyToStateCacheDict = {};
+    }
+    
+    /**
+     * Calls HiFiCommunicator callback instructing it to perform a transition.
+     */
+    private _onTransitionRequested(): void {
+        if (this.onTransitionRequested) {
+            this.onTransitionRequested();
+        }
+    }
+
+   /**
+     * Sends the command `audionet.transition-ready` to the mixer.
+     */
+    transitionReady() {
+        let commandController = this._raviSession.getCommandController();
+        if (!commandController) {
+            HiFiLogger.log(`Could not retrieve command controller during transitionReady`);
+            return;
+        }
+        commandController.queueCommand("audionet.transition-ready", {}, () => {});
+    }
+
+    /**
+     * Calls HiFiCommunicator callback instructing it to perform a transition.
+     */
+    private _onTransition(): void {
+        if (this.onTransition) {
+            this.onTransition();
+        }
+    }
+
+   /**
+     * Notifies the mixer that this client has completed transition.
+     */
+    transitionComplete() {
+        let commandController = this._raviSession.getCommandController();
+        if (!commandController) {
+            HiFiLogger.log(`Could not retrieve command controller during transitionComplete`);
+            return;
+        }
+        commandController.queueCommand("audionet.transition-complete", {}, () => {});
+    }
+
+   /**
+     * Swaps primary and secondary callbacks, and mutes the old primary mixer session, and unmutes the new primary mixer session.
+     */    
+    async transitionToSecondarySession(secondarySession: HiFiMixerSession) {
+        
+        [this.onConnectionStateChanged, secondarySession.onConnectionStateChanged] = [secondarySession.onConnectionStateChanged, this.onConnectionStateChanged];
+        [this.userDataStreamingScope, secondarySession.userDataStreamingScope] = [secondarySession.userDataStreamingScope, this.userDataStreamingScope];
+        [this.onUserDataUpdated, secondarySession.onUserDataUpdated] = [secondarySession.onUserDataUpdated, this.onUserDataUpdated];
+        [this.onUsersDisconnected, secondarySession.onUsersDisconnected] = [secondarySession.onUsersDisconnected, this.onUsersDisconnected];
+        [this.onMuteChanged, secondarySession.onMuteChanged] = [secondarySession.onMuteChanged, this.onMuteChanged];
+        [this.onTransitionRequested, secondarySession.onTransitionRequested] = [secondarySession.onTransitionRequested, this.onTransitionRequested];
+        [this.onTransition, secondarySession.onTransition] = [secondarySession.onTransition, this.onTransition];
+        [this.onReadyForTransition, secondarySession.onReadyForTransition] = [secondarySession.onReadyForTransition, this.onReadyForTransition];
+        [this._lastSuccessfulInputAudioMutedValue, secondarySession._lastSuccessfulInputAudioMutedValue] = [secondarySession._lastSuccessfulInputAudioMutedValue, this._lastSuccessfulInputAudioMutedValue];
+
+        this._disableReconnect = true;
+        secondarySession._disableReconnect = false;
+
+        HiFiLogger.debug("Setting new primary/old secondary session mute to communicator mute value.");
+        await secondarySession._trySetInputAudioMuted(secondarySession._lastSuccessfulInputAudioMutedValue, false);     
+        HiFiLogger.debug("Muting old primary/new secondary mixer session.");
+        await this._trySetInputAudioMuted(true, false);
+
+        // send deleted peer notifications for any peers that didn't make it over to the new mixer
+        // and send new peer data notifications for all peers that are on the new mixer.
+        let allDeletedUserData: Array<ReceivedHiFiAudioAPIData> = [];
+        let allNewUserData: Array<ReceivedHiFiAudioAPIData> = [];
+            
+
+        let oldPeers: any = {};
+        for (const mixerPeerKey of Object.keys(this._mixerPeerKeyToStateCacheDict)) {
+            oldPeers[this._mixerPeerKeyToStateCacheDict[mixerPeerKey].hashedVisitID] = this._mixerPeerKeyToStateCacheDict[mixerPeerKey];
+        }
+        for (const mixerPeerKey of Object.keys(secondarySession._mixerPeerKeyToStateCacheDict)) {
+            delete oldPeers[secondarySession._mixerPeerKeyToStateCacheDict[mixerPeerKey].hashedVisitID];
+            allNewUserData.push(secondarySession._mixerPeerKeyToStateCacheDict[mixerPeerKey]);
+        }
+        
+        for (const hashedVisitID of Object.keys(oldPeers)) {
+            let deletedUserData = new ReceivedHiFiAudioAPIData({
+                hashedVisitID: hashedVisitID
+            });
+            if (oldPeers[hashedVisitID].providedUserID) {
+                deletedUserData.providedUserID = oldPeers[hashedVisitID].providedUserID;
+            }
+            allDeletedUserData.push(deletedUserData);
+        }
+
+        if (secondarySession.onUsersDisconnected && allDeletedUserData.length > 0) {
+            secondarySession.onUsersDisconnected(allDeletedUserData);
+        }
+        if (secondarySession.onUserDataUpdated && allNewUserData.length > 0) {
+            secondarySession.onUserDataUpdated(allNewUserData);
+        }
+        this._mixerPeerKeyToStateCacheDict = {};
+        this.concurrency = 0;        
     }
 }

--- a/src/classes/HiFiMixerSession.ts
+++ b/src/classes/HiFiMixerSession.ts
@@ -338,6 +338,7 @@ export class HiFiMixerSession {
         this.onTransition = onTransition;
         this.onReadyForTransition = onReadyForTransition;
         this._inputAudioMediaStream = undefined;
+        this._inputAudioMediaStreamIsStereo = false;
         if (visitId) {
             this._visitId = visitId;
         } else {

--- a/src/classes/HiFiMixerSession.ts
+++ b/src/classes/HiFiMixerSession.ts
@@ -732,6 +732,9 @@ export class HiFiMixerSession {
             });
         })
         .then((value) => {
+            // need to copy the audio tracks here as we've not yet set up the ravi
+            // state change handler, which deals with copying the tracks during
+            // reconnect and transition
             this._copyAudioTracksFromRavi();           
             HiFiLogger.log(`Session open; running audionet.init`);
             return this.promiseToRunAudioInit(initData)


### PR DESCRIPTION
HiFi-923 - Allow multiple mixer sessions.
HIFI-924 - Transition handling.

https://highfidelity.atlassian.net/wiki/spaces/AudioNet/pages/2051309595/Mixer+Transitions
This PR does the following:
* Adds a second "secondaryMixerSession" to the HiFiCommunicator for connection to transition target mixer.
* Adds transition negotiation logic to perform transition as in the above spec.
* sends current user data via audionet.init when reconnecting.
